### PR TITLE
Adding locker#assert to not fail loudly.

### DIFF
--- a/lib/zk/locker/locker_base.rb
+++ b/lib/zk/locker/locker_base.rb
@@ -280,6 +280,19 @@ module ZK
         end
       end
 
+      def assert
+        return true if @mutex.synchronize do
+          break unless locked?
+          break unless zk.connected?
+          break unless lock_path
+          break unless zk.exists?(lock_path)
+          break unless root_lock_path_same?
+          break unless got_lock?
+          true
+        end
+        false
+      end
+
       private
         def lock_with_opts_hash(opts={})
           raise NotImplementedError

--- a/spec/zk/locker/locker_basic_spec.rb
+++ b/spec/zk/locker/locker_basic_spec.rb
@@ -32,6 +32,13 @@ describe 'ZK::Client#locker' do
     @zk2.locker(@path_to_lock).lock.should be_false
   end
 
+  it "should assert properly if lock is acquired" do
+    @zk.locker(@path_to_lock).assert.should be_false
+    l = @zk2.locker(@path_to_lock)
+    l.lock.should be_true
+    l.assert.should be_true
+  end
+
   it "should be able to acquire the lock after the first one releases it" do
     lock1 = @zk.locker(@path_to_lock)
     lock2 = @zk2.locker(@path_to_lock)


### PR DESCRIPTION
This is to close out request issue #48 on the Github repository. Basically return true
if we obtain the lock (and have a connection, etc.) otherwise return false and don't fail
loudly as locker#assert! does.
