### PR TITLE
Don't check connection state in Locker#assert!

### DIFF
--- a/lib/zk/locker/locker_base.rb
+++ b/lib/zk/locker/locker_base.rb
@@ -277,7 +277,6 @@ module ZK
       def assert!
         @mutex.synchronize do
           raise LockAssertionFailedError, "have not obtained the lock yet"            unless locked?
-          raise LockAssertionFailedError, "not connected"                             unless zk.connected?
           raise LockAssertionFailedError, "lock_path was #{lock_path.inspect}"        unless lock_path
           raise LockAssertionFailedError, "the lock path #{lock_path} did not exist!" unless zk.exists?(lock_path)
           raise LockAssertionFailedError, "the parent node was replaced!"             unless root_lock_path_same?


### PR DESCRIPTION
Rely on the call to zk.exists? to check that.

I've noticed that the threaded connection has a `:retry_duration` which would allow for temporary disconnections to be recovered from, but this check to `zk.connected?` prevents that from working.

This way, we can let the call to `zk.exists?` do the job of checking if we're connected, and it will place nice with reconnection.
