### PR TITLE
Really clear the hooks when `clear!` is called.

### DIFF
--- a/lib/zk/fork_hook.rb
+++ b/lib/zk/fork_hook.rb
@@ -39,7 +39,7 @@ module ZK
     
     # @private
     def clear!
-      @mutex.synchronize { @hooks.values(&:clear) }
+      @mutex.synchronize { @hooks.values.each(&:clear) }
     end
 
     # @private


### PR DESCRIPTION
Hash::values can apparently be called with a block, but the block is ignored.

Background: We use the zk gem is a ruby on rails application that includes a significant resque component. Unfortunately, the reconnect-on-fork behaviour adds a significant load to our zookeeper servers. The individual resque jobs do not need to do anything with zookeeper. I was going to avoid creating a zookeeper client if running in resque. The main process, however, can be connected to zookeeper so I'm also investigating whether or not we can simply close the zk connection in the child process. To do that, we need to circumvent the reconnect-on-fork functionality, first clearing the fork hooks and then adding our own, with `zk.close!` (?) being run in the child. Unfortunately, `ForkHook#clear!` does not actually do anything.
