### PR TITLE
Run tests against Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 
 # pull in releaseops submodule
 before_install:
+  - gem update bundler
   - git submodule update --init --recursive
 
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 2.2.0
-matrix:
-  allow_failures:
-    - rvm: 2.2.0
 
 # jruby specs are too intesive for travis
 #   - jruby-18mode

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :test do
   gem 'rspec', '~> 2.8.0'
   gem 'flexmock', '~> 0.8.10'
   gem 'zk-server', '~> 1.1.4'
+  gem 'test-unit', :platforms => [:ruby_22]
 end
 
 # Specify your gem's dependencies in zk.gemspec


### PR DESCRIPTION
Hi,

The reason why `flexmock` was failing in Ruby 2.2 is because Ruby 2.2 removed `test-unit` from its standard library. Specifying it as an explicit dependency allows tests to run (and pass) on Ruby 2.2.

On the side note: we are trying to upgrade our service discovery framework [airbnb/synapse](https://github.com/airbnb/synapse) to support Ruby 2.x. We've been seeing various failures reported by the community (airbnb/synapse#94, airbnb/synapse#134, airbnb/synapse#137) related to those Ruby versions so we might be sending more pull requests to zk and zookeeper gems if we discover incompatibilities with Ruby 2.x.

Thanks a lot!