### PR TITLE
Interrupt blocked locker

### DIFF
--- a/lib/zk/locker/locker_base.rb
+++ b/lib/zk/locker/locker_base.rb
@@ -291,6 +291,19 @@ module ZK
         false
       end
 
+      # interrupt caller blocked on acquring a lock by delegating to
+      # ZK::NodeDeletionWatcher#interrupt!
+      #
+      # this does nothing if the watcher is not currently blocked.
+      #
+      # @raise [WakeUpException] raised when caller interrupted
+      #
+      def interrupt!
+        synchronize do
+          @node_deletion_watcher and @node_deletion_watcher.interrupt!
+        end
+      end
+
       private
         def synchronize
           @mutex.synchronize { yield }


### PR DESCRIPTION
I have a program that tries to acquire a lock before doing any work and needed a way to interrupt it in order to shut down cleanly. Delegating to `NodeDeletionWatcher#interrupt!` seemed to do the trick.
