### PR TITLE
Fix rake dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,14 @@ source "https://rubygems.org"
 #   gem 'zookeeper', '~> 1.3.0'
 # end
 
-gem 'rake', :group => [:development, :test]
+group :development, :test do
+  if RUBY_VERSION >= '1.9.3'
+    gem 'rake'
+  else
+    gem 'rake', '~> 10.5'
+  end
+end
+
 gem 'pry',  :group => [:development]
 
 group :docs do


### PR DESCRIPTION
rake `11.1.2` requires ruby `1.9.3` or greater. Doing a switch based on `RUBY_VERSION` was the only way I found to handle specifying different versions of the same gem. Both `:platforms` and `:install_if` complain (understandably) if specifying different versions of the same gem:

```
[!] There was an error parsing `Gemfile`: You cannot specify the same gem twice with different version requirements.
You specified: rake (< 11.1.2) and rake (>= 0). Bundler cannot continue.

 #  from /Users/larry/Code/zk/Gemfile:17
 #  -------------------------------------------
 #    gem 'rake', '< 11.1.2', :platforms => [ :ruby_18, :ruby_19 ]
 >    gem 'rake', :platforms => :ruby_20
 #  end
 #  -------------------------------------------
```