### PR TITLE
Updates for Ruby 2.3.0, 2.4.0 and RSpec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 2.2.0
+  - 2.3.0
+  - 2.4.0
+  - 2.5.0
 
 # jruby specs are too intesive for travis
 #   - jruby-18mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,11 @@ before_install:
 rvm:
   - 1.9.3
   - 1.9.2
-  - 1.8.7
-  - ree
   - 2.0.0
   - 2.1.0
   - 2.2.0
   - 2.3.0
   - 2.4.0
-  - 2.5.0
 
 # jruby specs are too intesive for travis
 #   - jruby-18mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,13 @@ before_install:
   - git submodule update --init --recursive
 
 rvm:
-  - 1.9.3
   - 1.9.2
+  - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.0
-  - 2.3.0
-  - 2.4.0
+  - 2.3.6
+  - 2.4.3
 
 # jruby specs are too intesive for travis
 #   - jruby-18mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,12 @@ before_install:
   - git submodule update --init --recursive
 
 rvm:
+  - ree
+  - jruby-18mode
+  - jruby-19mode
+  - rbx-18mode
+  - rbx-19mode
+  - 1.8.7
   - 1.9.2
   - 1.9.3
   - 2.0.0
@@ -22,6 +28,16 @@ rvm:
   - 2.2.0
   - 2.3.6
   - 2.4.3
+  - 2.5.0
+matrix:
+  allow_failures:
+    - rvm: ree
+    - rvm: jruby-18mode
+    - rvm: jruby-19mode
+    - rvm: rbx-18mode
+    - rvm: rbx-19mode
+    - rvm: 1.8.7
+    - rvm: 2.5.0
 
 # jruby specs are too intesive for travis
 #   - jruby-18mode

--- a/Gemfile
+++ b/Gemfile
@@ -51,8 +51,7 @@ group :development do
 end
 
 group :test do
-  gem 'rspec', '~> 2.14.0'
-  gem 'flexmock', '~> 0.8.10'
+  gem 'rspec', '~> 3.6.0'
   gem 'zk-server', '~> 1.1.4'
   gem 'test-unit', :platforms => [:ruby_22, :ruby_23, :ruby_24]
 end

--- a/Gemfile
+++ b/Gemfile
@@ -43,14 +43,13 @@ group :development do
     gem 'rb-readline', :platform => :ruby
   end
 
-  gem 'pry'
-
   platform :mri do
     gem 'pry-byebug'
   end
 end
 
 group :test do
+  gem 'pry'
   gem 'rspec', '~> 3.6.0'
   gem 'zk-server', '~> 1.1.4'
   gem 'test-unit', :platforms => [:ruby_22, :ruby_23, :ruby_24]

--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,6 @@ group :development, :test do
   end
 end
 
-gem 'pry',  :group => [:development]
-
 group :docs do
   gem 'yard', '~> 0.8.0'
 
@@ -44,13 +42,19 @@ group :development do
     gem 'growl',       :require => false
     gem 'rb-readline', :platform => :ruby
   end
+
+  gem 'pry'
+
+  platform :mri do
+    gem 'pry-byebug'
+  end
 end
 
 group :test do
-  gem 'rspec', '~> 2.8.0'
+  gem 'rspec', '~> 2.14.0'
   gem 'flexmock', '~> 0.8.10'
   gem 'zk-server', '~> 1.1.4'
-  gem 'test-unit', :platforms => [:ruby_22]
+  gem 'test-unit', :platforms => [:ruby_22, :ruby_23, :ruby_24]
 end
 
 # Specify your gem's dependencies in zk.gemspec

--- a/lib/zk/client.rb
+++ b/lib/zk/client.rb
@@ -6,7 +6,7 @@ module ZK
   # Once you've had a look there, take a look at {Client::Conveniences},
   # {Client::StateMixin}, and {Client::Unixisms}
   #
-  # @todo ACL support is pretty much unused currently. 
+  # @todo ACL support is pretty much unused currently.
   #   If anyone has suggestions, hints, use-cases, examples, etc. by all means please file a bug.
   #
   module Client

--- a/lib/zk/fork_hook.rb
+++ b/lib/zk/fork_hook.rb
@@ -3,13 +3,13 @@ module ZK
     include ZK::Logger
     extend self
 
-    @mutex = Mutex.new unless @mutex
+    @mutex = Mutex.new unless defined?(@mutex)
 
     @hooks = {
       :prepare      => [],
       :after_child  => [],
       :after_parent => [],
-    } unless @hooks
+    } unless defined?(@hooks)
 
     attr_reader :hooks, :mutex
 

--- a/lib/zk/locker/semaphore.rb
+++ b/lib/zk/locker/semaphore.rb
@@ -2,8 +2,6 @@ module ZK
   module Locker
     # A semaphore implementation
     class Semaphore < LockerBase
-      include Exceptions
-
       @default_root_node = '/_zksemaphore'.freeze unless @default_root_node
 
       class << self
@@ -13,7 +11,7 @@ module ZK
       end
 
       def initialize(client, name, semaphore_size, root_node=nil)
-        raise BadArgument, <<-EOMESSAGE unless semaphore_size.kind_of? Integer
+        raise ZK::Exceptions::BadArguments, <<-EOMESSAGE unless semaphore_size.kind_of? Integer
           semaphore_size must be Integer, not #{semaphore_size.inspect}
         EOMESSAGE
 

--- a/lib/zk/node_deletion_watcher.rb
+++ b/lib/zk/node_deletion_watcher.rb
@@ -88,7 +88,7 @@ module ZK
         start = Time.now
         time_to_stop = timeout ? (start + timeout) : nil
 
-        logger.debug { "#{__method__} @blocked: #{@blocked.inspect} about to wait" } 
+        logger.debug { "#{__method__} @blocked: #{@blocked.inspect} about to wait" }
         @cond.wait(timeout)
 
         if (time_to_stop and (Time.now > time_to_stop)) and (@blocked == NOT_YET)
@@ -100,7 +100,7 @@ module ZK
     end
 
     # cause a thread blocked by us to be awakened and have a WakeUpException
-    # raised. 
+    # raised.
     #
     # if a result has already been delivered, then this does nothing
     #

--- a/lib/zk/node_deletion_watcher.rb
+++ b/lib/zk/node_deletion_watcher.rb
@@ -1,7 +1,6 @@
 module ZK
   class NodeDeletionWatcher
     include Zookeeper::Constants
-    include Exceptions
     include Logger
 
     # @private
@@ -42,7 +41,7 @@ module ZK
       @paths      = paths.dup
       @options    = options.dup
       @threshold  = options[:threshold] || 0
-      raise BadArgument, <<-EOBADARG unless @threshold.kind_of? Integer
+      raise ZK::Exceptions::BadArguments, <<-EOBADARG unless @threshold.kind_of? Integer
         options[:threshold] must be an Integer. Got #{@threshold.inspect}."
       EOBADARG
 

--- a/lib/zk/pool.rb
+++ b/lib/zk/pool.rb
@@ -1,18 +1,18 @@
 module ZK
   module Pool
-    # Base class for a ZK connection pool. There are some applications that may 
+    # Base class for a ZK connection pool. There are some applications that may
     # require high synchronous throughput, which would be a suitable use for a
     # connection pool. The ZK::Client::Threaded class is threadsafe, so it's
     # not a problem accessing it from multiple threads, but it is limited to
     # one outgoing synchronous request at a time, which could cause throughput
-    # issues for apps that are making very heavy use of zookeeper. 
+    # issues for apps that are making very heavy use of zookeeper.
     #
     # The problem with using a connection pool is the added complexity when you
     # try to use watchers. It may be possible to register a watch with one
     # connection, and then call `:watch => true` on a different connection if
     # you're not careful. Events delivered as part of an event handler have a
     # `zk` attribute which can be used to access the connection that the
-    # callback is registered with. 
+    # callback is registered with.
     #
     # Unless you're sure you *need* a connection pool, then avoid the added
     # complexity.
@@ -27,7 +27,7 @@ module ZK
 
         @mutex  = Monitor.new
         @checkin_cond = @mutex.new_cond
-        
+
         @connections = []     # all connections we control
         @pool = []            # currently available connections
 
@@ -58,7 +58,7 @@ module ZK
 
       # close all the connections on the pool
       def close_all!
-        @mutex.synchronize do 
+        @mutex.synchronize do
           return unless open?
           @state = :closing
 
@@ -86,7 +86,7 @@ module ZK
 
           @state = :closed
 
-          # free any waiting 
+          # free any waiting
           @checkin_cond.broadcast
         end
       end
@@ -146,7 +146,7 @@ module ZK
         end
 
         def assert_open!
-          raise Exceptions::PoolIsShuttingDownException, "pool is shutting down" unless open? 
+          raise Exceptions::PoolIsShuttingDownException, "pool is shutting down" unless open?
         end
 
     end # Base
@@ -211,7 +211,7 @@ module ZK
         @mutex.synchronize { @count_waiters }
       end
 
-      def checkout(blocking=true) 
+      def checkout(blocking=true)
         raise ArgumentError, "checkout does not take a block, use .with_connection" if block_given?
         @mutex.lock
         begin
@@ -224,7 +224,7 @@ module ZK
               # XXX(slyphon): not really sure how this case happens, but protect against it as we're
               # seeing an issue in production
               next if cnx.nil?
-              
+
               # if the connection isn't connected, then set up an on_connection
               # handler and try the next one in the pool
               unless cnx.connected?
@@ -263,7 +263,7 @@ module ZK
         def add_connection!
           @mutex.synchronize do
             cnx = create_connection
-            @connections << cnx 
+            @connections << cnx
 
             handle_checkin_on_connection(cnx)
           end # synchronize
@@ -281,7 +281,7 @@ module ZK
             else
               @on_connected_subs.synchronize do
 
-                sub = cnx.on_connected do 
+                sub = cnx.on_connected do
                   # this synchronization is to prevent a race between setting up the subscription
                   # and assigning it to the @on_connected_subs hash. It's possible that the callback
                   # would fire before we had a chance to add the sub to the hash.

--- a/spec/event_catcher_spec.rb
+++ b/spec/event_catcher_spec.rb
@@ -25,7 +25,7 @@ describe EventCatcher do
 
       subject.add(:created, 'blah')
 
-      th.join(2).value.should be_true
+      expect(th.join(2).value).to be(true)
     end
   end
 end

--- a/spec/message_queue_spec.rb
+++ b/spec/message_queue_spec.rb
@@ -22,35 +22,35 @@ describe ZK::MessageQueue do
   it "should be able to receive a published message" do
     message_received = false
     @consume_queue.subscribe do |title, data|
-      data.should == 'mydata'
+      expect(data).to eq('mydata')
       message_received = true
     end
     @publish_queue.publish("mydata")
     wait_until {message_received }
-    message_received.should be_true
+    expect(message_received).to be(true)
   end
 
   it "should be able to receive a custom message title" do
     message_title = false
     @consume_queue.subscribe do |title, data|
-      title.should == 'title'
+      expect(title).to eq('title')
       message_title = true
     end
     @publish_queue.publish("data", "title")
     wait_until { message_title }
-    message_title.should be_true
+    expect(message_title).to be(true)
   end
 
   it "should work even after processing a message from before" do
     @publish_queue.publish("data1", "title")
     message_times = 0
     @consume_queue.subscribe do |title, data|
-      title.should == "title"
+      expect(title).to eq("title")
       message_times += 1
     end
 
     @publish_queue.publish("data2", "title")
     wait_until { message_times == 2 }
-    message_times.should == 2
+    expect(message_times).to eq(2)
   end
 end

--- a/spec/shared/client_examples.rb
+++ b/spec/shared/client_examples.rb
@@ -6,7 +6,7 @@ shared_examples_for 'client' do
       @path_ary = %W[#{base} test mkdir_p path creation]
       @bogus_path = File.join('', *@path_ary)
     end
-   
+
     it %[should create all intermediate paths for the path givem] do
       expect(@zk.exists?(@bogus_path)).to be(false)
       expect(@zk.exists?(File.dirname(@bogus_path))).to be(false)
@@ -140,7 +140,7 @@ shared_examples_for 'client' do
       end
 
       def create_args(opts={})
-        proc do 
+        proc do
           begin
             @zk.create(path, opts.merge(:or => :set))
           ensure
@@ -197,7 +197,7 @@ shared_examples_for 'client' do
       before do
         @missing_path = '/thispathdoesnotexist'
         begin
-          @zk.delete(@missing_path) 
+          @zk.delete(@missing_path)
         rescue ZK::Exceptions::NoNode
         end
       end
@@ -296,22 +296,22 @@ shared_examples_for 'client' do
       end
 
 #       after do
-#         logger.info { "AFTER EACH" } 
+#         logger.info { "AFTER EACH" }
 #         @zk.delete(@path)
 #       end
 
       def ensure_event_delivery!
         @sub ||= @zk.event_handler.register(@path) do |event|
-          logger.debug { "got event: #{event.inspect}" } 
+          logger.debug { "got event: #{event.inspect}" }
           @queue << event
         end
 
         expect(@zk.exists?(@path, :watch => true)).to be(false)
         @zk.create(@path)
 
-        logger.debug { "waiting for event delivery" } 
+        logger.debug { "waiting for event delivery" }
 
-        wait_until(2) do 
+        wait_until(2) do
           begin
             event = @queue.pop(true)
             logger.debug { "got event: #{event}" }
@@ -357,14 +357,14 @@ shared_examples_for 'client' do
       # note: we can't trust the events to be delivered in any particular order
       # since they're happening on two different threads. if we see we're connected
       # in the beginning, that there was a disconnection, then a reopen, that's
-      # probably fine. 
+      # probably fine.
       #
       # we also check that the session_id was changed, which is the desired effect
 
       orig_session_id = @zk.session_id
       expect(@zk).to be_connected
 
-      props = { 
+      props = {
         :session_event?   => true,
         :node_event?      => false,
         :client_invalid?  => true,
@@ -392,7 +392,7 @@ shared_examples_for 'client' do
         @zk.event_handler.process(bogus_event)
       end
 
-      logger.debug { "events: #{events.inspect}" } 
+      logger.debug { "events: #{events.inspect}" }
 
       mutex.synchronize do
         time_to_stop = Time.now + 2
@@ -410,7 +410,7 @@ shared_examples_for 'client' do
       @ary = []
 
       @zk.on_exception { |exc| @ary << exc }
-        
+
       @zk.defer { raise "ZOMG!" }
 
       wait_while(2) { @ary.empty? }

--- a/spec/shared/client_examples.rb
+++ b/spec/shared/client_examples.rb
@@ -8,27 +8,27 @@ shared_examples_for 'client' do
     end
    
     it %[should create all intermediate paths for the path givem] do
-      @zk.should_not be_exists(@bogus_path)
-      @zk.should_not be_exists(File.dirname(@bogus_path))
+      expect(@zk.exists?(@bogus_path)).to be(false)
+      expect(@zk.exists?(File.dirname(@bogus_path))).to be(false)
       @zk.mkdir_p(@bogus_path)
-      @zk.should be_exists(@bogus_path)
+      expect(@zk.exists?(@bogus_path)).to be(true)
     end
 
     it %[should place the data only at the leaf node] do
       @zk.mkdir_p(@bogus_path, :data => 'foobar')
-      @zk.get(@bogus_path).first.should == 'foobar'
+      expect(@zk.get(@bogus_path).first).to eq('foobar')
 
       path = ''
       @path_ary[0..-2].each do |el|
         path = File.join(path, el)
-        @zk.get(path).first.should == ''
+        expect(@zk.get(path).first).to eq('')
       end
     end
 
     it %[should replace the data at the leaf node if it already exists] do
       @zk.mkdir_p(@bogus_path, :data => 'blahfoo')
       @zk.mkdir_p(@bogus_path, :data => 'foodink')
-      @zk.get(@bogus_path).first.should == 'foodink'
+      expect(@zk.get(@bogus_path).first).to eq('foodink')
     end
   end
 
@@ -37,14 +37,14 @@ shared_examples_for 'client' do
     describe 'only path given' do
       it %[should create a node with blank data] do
         @zk.create(@base_path)
-        @zk.get(@base_path).first.should == ''
+        expect(@zk.get(@base_path).first).to eq('')
       end
     end
 
     describe 'path and data given' do
       it %[should create a node with the path and data] do
         @zk.create(@base_path, 'blah')
-        @zk.get(@base_path).first.should == 'blah'
+        expect(@zk.get(@base_path).first).to eq('blah')
       end
     end
 
@@ -52,37 +52,37 @@ shared_examples_for 'client' do
       it %[should create a sequential node with blank data] do
         @zk.create(@base_path)
         path = @zk.create("#{@base_path}/v", :sequential => true)
-        path.start_with?(@base_path).should be_true
+        expect(path.start_with?(@base_path)).to be(true)
 
-        File.basename(path).should match(/v\d+/)
+        expect(File.basename(path)).to match(/v\d+/)
 
-        @zk.get(path).first.should == ''
+        expect(@zk.get(path).first).to eq('')
       end
 
       it %[should create a sequential node with given data] do
         @zk.create(@base_path)
         path = @zk.create("#{@base_path}/v", 'thedata', :sequential => true)
-        path.start_with?(@base_path).should be_true
+        expect(path.start_with?(@base_path)).to be(true)
 
-        File.basename(path).should match(/v\d+/)
+        expect(File.basename(path)).to match(/v\d+/)
 
         data, st = @zk.get(path)
-        data.should == 'thedata'
-        st.should_not be_ephemeral
+        expect(data).to eq('thedata')
+        expect(st).not_to be_ephemeral
       end
     end
 
     describe 'path and ephemeral' do
       it %[should create an ephemeral node with blank data] do
         @zk.create(@base_path, :ephemeral => true)
-        @zk.get(@base_path).last.should be_ephemeral
+        expect(@zk.get(@base_path).last).to be_ephemeral
       end
 
       it %[should create an ephemeral node with given data] do
         @zk.create(@base_path, 'thedata', :ephemeral => true)
         data, stat = @zk.get(@base_path)
-        data.should == 'thedata'
-        stat.should be_ephemeral
+        expect(data).to eq('thedata')
+        expect(stat).to be_ephemeral
       end
     end
 
@@ -90,45 +90,45 @@ shared_examples_for 'client' do
       it %[should create a sequential ephemeral node with blank data] do
         @zk.create(@base_path)
         path = @zk.create("#{@base_path}/v", :sequential => true, :ephemeral => true)
-        path.start_with?(@base_path).should be_true
+        expect(path.start_with?(@base_path)).to be(true)
 
-        File.basename(path).should match(/v\d+/)
+        expect(File.basename(path)).to match(/v\d+/)
 
         data, st = @zk.get(path)
-        data.should == ''
-        st.should be_ephemeral
+        expect(data).to eq('')
+        expect(st).to be_ephemeral
       end
 
       it %[should create a sequential ephemeral node with given data] do
         @zk.create(@base_path)
         path = @zk.create("#{@base_path}/v", 'thedata', :sequential => true, :ephemeral => true)
-        path.start_with?(@base_path).should be_true
+        expect(path.start_with?(@base_path)).to be(true)
 
-        File.basename(path).should match(/v\d+/)
+        expect(File.basename(path)).to match(/v\d+/)
 
         data, st = @zk.get(path)
-        data.should == 'thedata'
-        st.should be_ephemeral
+        expect(data).to eq('thedata')
+        expect(st).to be_ephemeral
       end
     end
 
     it %[should barf if someone hands 3 params] do
-      lambda { @zk.create(@base_path, 'data', :sequence) }.should raise_error(ArgumentError)
+      expect { @zk.create(@base_path, 'data', :sequence) }.to raise_error(ArgumentError)
     end
 
     it %[should barf if both :sequence and :sequential are given] do
-      lambda { @zk.create(@base_path, 'data', :sequence => true, :sequential => true) }.should raise_error(ArgumentError)
+      expect { @zk.create(@base_path, 'data', :sequence => true, :sequential => true) }.to raise_error(ArgumentError)
     end
 
     describe %[:ignore option] do
       it %[should squelch node_exists] do
         @zk.create(@base_path)
 
-        proc { @zk.create(@base_path, :ignore => :node_exists).should be_nil }.should_not raise_error(ZK::Exceptions::NoNode)
+        expect { expect(@zk.create(@base_path, :ignore => :node_exists)).to be_nil }.not_to raise_error
       end
 
       it %[should squelch no_node] do
-        proc { @zk.create("#{@base_path}/foo/bar/baz", :ignore => :no_node).should be_nil }.should_not raise_error(ZK::Exceptions::NoNode)
+        expect { expect(@zk.create("#{@base_path}/foo/bar/baz", :ignore => :no_node)).to be_nil }.not_to raise_error
       end
     end
 
@@ -136,7 +136,7 @@ shared_examples_for 'client' do
       let(:path) { "#{@base_path}/foo/bar" }
 
       it %[should barf if anything but the the :set value is given] do
-        proc { @zk.create(path, :or => :GFY) }.should raise_error(ArgumentError)
+        expect { @zk.create(path, :or => :GFY) }.to raise_error(ArgumentError)
       end
 
       def create_args(opts={})
@@ -150,24 +150,24 @@ shared_examples_for 'client' do
       end
 
       it %[should barf if any node option besides 'persistent' is given] do
-        create_args(:persistent => true).should_not         raise_error
-        create_args(:sequential => true).should             raise_error(ArgumentError)
-        create_args(:mode => :ephemeral).should             raise_error(ArgumentError)
-        create_args(:mode => :ephemeral_sequential).should  raise_error(ArgumentError)
-        create_args(:mode => :sequential).should            raise_error(ArgumentError)
+        expect(create_args(:persistent => true)).not_to         raise_error
+        expect(create_args(:sequential => true)).to             raise_error(ArgumentError)
+        expect(create_args(:mode => :ephemeral)).to             raise_error(ArgumentError)
+        expect(create_args(:mode => :ephemeral_sequential)).to  raise_error(ArgumentError)
+        expect(create_args(:mode => :sequential)).to            raise_error(ArgumentError)
       end
 
       it %[should replace the data at the leaf node if it already exists] do
         @zk.mkdir_p(path, :data => 'foodink')
         @zk.create(path, 'blahfoo', :or => :set)
-        @zk.get(path).first.should == 'blahfoo'
+        expect(@zk.get(path).first).to eq('blahfoo')
       end
 
       it %[should create the intermediate paths] do
-        proc { @zk.create(path, 'foobar', :or => :set) }.should_not raise_error
+        expect { @zk.create(path, 'foobar', :or => :set) }.not_to raise_error
 
-        @zk.stat(@base_path).should exist
-        @zk.stat("#{@base_path}/foo").should exist
+        expect(@zk.stat(@base_path)).to exist
+        expect(@zk.stat("#{@base_path}/foo")).to exist
       end
     end
   end
@@ -178,16 +178,16 @@ shared_examples_for 'client' do
         @zk.create(@base_path)
         @zk.create("#{@base_path}/blah")
 
-        proc { @zk.delete(@base_path, :ignore => :not_empty).should be_nil }.should_not raise_error
+        expect { expect(@zk.delete(@base_path, :ignore => :not_empty)).to be_nil }.not_to raise_error
       end
 
       it %[should squelch no_node] do
-        proc { @zk.delete("#{@base_path}/foo/bar/baz", :ignore => :no_node).should be_nil }.should_not raise_error
+        expect { expect(@zk.delete("#{@base_path}/foo/bar/baz", :ignore => :no_node)).to be_nil }.not_to raise_error
       end
 
       it %[should squelch bad_version] do
         @zk.create(@base_path)
-        proc { @zk.delete("#{@base_path}", :version => 7, :ignore => :bad_version).should be_nil }.should_not raise_error
+        expect { expect(@zk.delete("#{@base_path}", :version => 7, :ignore => :bad_version)).to be_nil }.not_to raise_error
       end
     end
   end
@@ -203,15 +203,15 @@ shared_examples_for 'client' do
       end
 
       it %[should not raise any error] do
-        lambda { @zk.stat(@missing_path) }.should_not raise_error
+        expect { @zk.stat(@missing_path) }.not_to raise_error
       end
 
       it %[should return a Stat object] do
-        @zk.stat(@missing_path).should be_kind_of(Zookeeper::Stat)
+        expect(@zk.stat(@missing_path)).to be_kind_of(Zookeeper::Stat)
       end
 
       it %[should return a stat that not exists?] do
-        @zk.stat(@missing_path).should_not be_exists
+        expect(@zk.stat(@missing_path)).not_to be_exists
       end
     end
   end
@@ -219,12 +219,12 @@ shared_examples_for 'client' do
   describe :set do
     describe %[:ignore option] do
       it %[should squelch no_node] do
-        proc { @zk.set("#{@base_path}/foo/bar/baz", '', :ignore => :no_node).should be_nil }.should_not raise_error
+        expect { expect(@zk.set("#{@base_path}/foo/bar/baz", '', :ignore => :no_node)).to be_nil }.not_to raise_error
       end
 
       it %[should squelch bad_version] do
         @zk.create(@base_path)
-        proc { @zk.set("#{@base_path}", '', :version => 7, :ignore => :bad_version).should be_nil }.should_not raise_error
+        expect { expect(@zk.set("#{@base_path}", '', :version => 7, :ignore => :bad_version)).to be_nil }.not_to raise_error
       end
     end
   end
@@ -236,7 +236,7 @@ shared_examples_for 'client' do
 
     describe 'no node initially' do
       before do
-        @zk.exists?(@path).should be_false
+        expect(@zk.exists?(@path)).to be(false)
       end
 
       it %[should not block] do
@@ -248,42 +248,42 @@ shared_examples_for 'client' do
         end
 
         th.join(2)
-        @a.should be_true
+        expect(@a).to be(true)
       end
     end
 
     describe 'node exists initially' do
       before do
         @zk.create(@path, :mode => :ephemeral)
-        @zk.exists?(@path).should be_true
+        expect(@zk.exists?(@path)).to be(true)
       end
 
       it %[should block until the node is deleted] do
         @a = false
 
-        th = Thread.new do
+        Thread.new do
           @zk.block_until_node_deleted(@path)
           @a = true
         end
 
         Thread.pass
-        @a.should be_false
+        expect(@a).to be(false)
 
         @zk.delete(@path)
 
         wait_until(2) { @a }
-        @a.should be_true
+        expect(@a).to be(true)
       end
     end
   end
 
   describe 'session_id and session_passwd' do
     it %[should expose the underlying session_id] do
-      @zk.session_id.should be_kind_of(Integer)
+      expect(@zk.session_id).to be_kind_of(Integer)
     end
 
     it %[should expose the underlying session_passwd] do
-      @zk.session_passwd.should be_kind_of(String)
+      expect(@zk.session_passwd).to be_kind_of(String)
     end
   end
 
@@ -306,7 +306,7 @@ shared_examples_for 'client' do
           @queue << event
         end
 
-        @zk.exists?(@path, :watch => true).should be_false
+        expect(@zk.exists?(@path, :watch => true)).to be(false)
         @zk.create(@path)
 
         logger.debug { "waiting for event delivery" } 
@@ -323,7 +323,7 @@ shared_examples_for 'client' do
         end
 
         # first watch delivered correctly
-        @events.length.should > 0
+        expect(@events.length).to be > 0
       end
 
       it %[should fire re-registered watchers after reopen (#9)] do
@@ -362,7 +362,7 @@ shared_examples_for 'client' do
       # we also check that the session_id was changed, which is the desired effect
 
       orig_session_id = @zk.session_id
-      @zk.should be_connected
+      expect(@zk).to be_connected
 
       props = { 
         :session_event?   => true,
@@ -372,8 +372,8 @@ shared_examples_for 'client' do
         :state            => Zookeeper::ZOO_EXPIRED_SESSION_STATE,
       }
 
-      bogus_event = flexmock(:expired_session_event, props)
-      bogus_event.should_receive(:zk=).with(@zk).once
+      bogus_event = instance_double(Zookeeper::Callbacks::WatcherCallback, props)
+      expect(bogus_event).to receive(:zk=).with(@zk).once
 
       mutex = Monitor.new
       cond  = mutex.new_cond
@@ -388,7 +388,7 @@ shared_examples_for 'client' do
       end
 
       mutex.synchronize do
-        events.should be_empty
+        expect(events).to be_empty
         @zk.event_handler.process(bogus_event)
       end
 
@@ -399,9 +399,9 @@ shared_examples_for 'client' do
         cond.wait_while { (events.length < 2 ) && (Time.now < time_to_stop) }
       end
 
-      events.should include(Zookeeper::ZOO_EXPIRED_SESSION_STATE) 
-      events.should include(Zookeeper::ZOO_CONNECTED_STATE)
-      @zk.session_id.should_not == orig_session_id
+      expect(events).to include(Zookeeper::ZOO_EXPIRED_SESSION_STATE)
+      expect(events).to include(Zookeeper::ZOO_CONNECTED_STATE)
+      expect(@zk.session_id).not_to eq(orig_session_id)
     end
   end # reconnection
 
@@ -415,12 +415,12 @@ shared_examples_for 'client' do
 
       wait_while(2) { @ary.empty? }
 
-      @ary.length.should == 1
+      expect(@ary.length).to eq(1)
 
       e = @ary.shift
 
-      e.should be_kind_of(RuntimeError)
-      e.message.should == 'ZOMG!'
+      expect(e).to be_kind_of(RuntimeError)
+      expect(e.message).to eq('ZOMG!')
     end
   end
 
@@ -431,8 +431,8 @@ shared_examples_for 'client' do
       @zk.defer { @ary << @zk.on_threadpool? }
 
       wait_while(2) { @ary.empty? }
-      @ary.length.should == 1
-      @ary.first.should be_true
+      expect(@ary.length).to eq(1)
+      expect(@ary.first).to be(true)
     end
   end
 end

--- a/spec/shared/locker_examples.rb
+++ b/spec/shared/locker_examples.rb
@@ -6,50 +6,50 @@
 shared_examples_for 'LockerBase#assert!' do
   it %[should raise LockAssertionFailedError if its connection is no longer connected?] do
     zk.close!
-    lambda { locker.assert! }.should raise_error(ZK::Exceptions::LockAssertionFailedError)
+    expect { locker.assert! }.to raise_error(ZK::Exceptions::LockAssertionFailedError)
   end
 
   it %[should raise LockAssertionFailedError if locked? is false] do
-    locker.should_not be_locked
-    lambda { locker.assert! }.should raise_error(ZK::Exceptions::LockAssertionFailedError)
+    expect(locker).not_to be_locked
+    expect { locker.assert! }.to raise_error(ZK::Exceptions::LockAssertionFailedError)
   end
 
   it %[should raise LockAssertionFailedError lock_path does not exist] do
     locker.lock
-    lambda { locker.assert! }.should_not raise_error
+    expect { locker.assert! }.not_to raise_error
 
     zk.delete(locker.lock_path)
-    lambda { locker.assert! }.should raise_error(ZK::Exceptions::LockAssertionFailedError)
+    expect { locker.assert! }.to raise_error(ZK::Exceptions::LockAssertionFailedError)
   end
 
   it %[should raise LockAssertionFailedError if our parent node's ctime is different than what we think it should be] do
-    locker.lock.should be_true
+    expect(locker.lock).to be(true)
 
     zk.rm_rf(File.dirname(locker.lock_path)) # remove the parent node
     zk.mkdir_p(locker.lock_path)
 
-    lambda { locker.assert! }.should raise_error(ZK::Exceptions::LockAssertionFailedError)
+    expect { locker.assert! }.to raise_error(ZK::Exceptions::LockAssertionFailedError)
   end
 end
 
 shared_examples_for 'LockerBase#unlock' do
   it %[should not delete a lock path it does not own] do
-    locker.lock.should be_true
+    expect(locker.lock).to be(true)
 
     zk.rm_rf(File.dirname(locker.lock_path)) # remove the parent node
     zk.mkdir_p(File.dirname(locker.lock_path))
 
-    locker2.lock.should be_true
+    expect(locker2.lock).to be(true)
 
-    locker2.lock_path.should == locker.lock_path
+    expect(locker2.lock_path).to eq(locker.lock_path)
 
-    lambda { locker2.assert! }.should_not raise_error
+    expect { locker2.assert! }.not_to raise_error
 
     lock_path = locker.lock_path
 
-    locker.unlock.should be_false
+    expect(locker.unlock).to be(false)
 
-    zk.stat(lock_path).should exist
+    expect(zk.stat(lock_path)).to exist
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,6 @@ if File.exists?(release_ops_path)
   ReleaseOps::SimpleCov.maybe_start
 end
 
-
 Bundler.require(:development, :test)
 
 require 'zk'
@@ -47,7 +46,7 @@ RSpec.configure do |config|
   if ZK.spawn_zookeeper?
     require 'zk-server'
 
-    config.before(:suite) do 
+    config.before(:suite) do
       SpecGlobalLogger.logger.debug { "Starting zookeeper service" }
       ZK::Server.run do |c|
         c.client_port = ZK.test_port
@@ -67,13 +66,13 @@ RSpec.configure do |config|
     count = 0
     ObjectSpace.each_object(klass) { |o| count += 1 if tester.call(o) }
     unless count.zero?
-      raise "There were #{count} leaked #{klass} objects after #{example.full_description.inspect}" 
+      raise "There were #{count} leaked #{klass} objects after #{example.full_description.inspect}"
     end
   end
 
   # these make tests run slow
   if ENV['ZK_LEAK_CHECK']
-    config.after do 
+    config.after do
       leak_check(ZK::Client::Threaded) { |o| !o.closed? }
       leak_check(ZK::ThreadedCallback, &:alive?)
       leak_check(ZK::Threadpool, &:alive?)
@@ -84,7 +83,7 @@ RSpec.configure do |config|
 end
 
 class ::Thread
-  # join with thread until given block is true, the thread joins successfully, 
+  # join with thread until given block is true, the thread joins successfully,
   # or timeout seconds have passed
   #
   def join_until(timeout=2)
@@ -96,7 +95,7 @@ class ::Thread
       Thread.pass
     end
   end
-  
+
   def join_while(timeout=2)
     time_to_stop = Time.now + timeout
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,14 +14,13 @@ Bundler.require(:development, :test)
 
 require 'zk'
 require 'benchmark'
+require 'pry'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
 Dir[File.expand_path("../{support,shared}/**/*.rb", __FILE__)].sort.each {|f| require f}
 
 $stderr.sync = true
-
-require 'flexmock'
 
 RSpec.configure do |config|
   config.mock_with :flexmock

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,50 +60,6 @@ RSpec.configure do |config|
       SpecGlobalLogger.logger.debug  { "stopping zookeeper service" }
       ZK::Server.shutdown
     end
-
-    config.before(:each, zookeeper: true) do
-      ZK.open("#{ZK.default_host}:#{ZK.test_port}") do |zk|
-        zk.rm_rf("/test")
-        zk.mkdir_p("/test")
-      end
-    end
-
-    config.before(:each, proxy: true) do |group|
-      proxy_start(group.metadata[:throttle_bytes_per_sec])
-    end
-
-    config.after(:each, proxy: true) do
-      proxy_stop
-    end
-
-    def proxy_start(throttle_bytes_per_sec = nil)
-      limit = "-L #{throttle_bytes_per_sec}" if throttle_bytes_per_sec
-      spawn(%{socat -T 10 -d TCP-LISTEN:#{ZK.test_proxy_port},fork,reuseaddr,linger=1 SYSTEM:'pv -q #{limit} - | socat - "TCP:localhost:#{ZK.test_port}"'})
-    end
-
-    def proxy_stop
-      system("lsof -i TCP:#{ZK.test_proxy_port} -t | grep -v #{Process.pid} | xargs kill -9")
-    end
-
-    def spawn(cmd)
-      puts "+ #{cmd}" if ENV['ZK_DEBUG']
-      Kernel.spawn(cmd)
-    end
-
-    def system(cmd)
-      puts "+ #{cmd}" if ENV['ZK_DEBUG']
-      Kernel.system(cmd)
-    end
-
-    def almost_there(tries = 100)
-      i ||= 0
-      yield
-    rescue RSpec::Expectations::ExpectationNotMetError
-      raise if i > tries
-      sleep 0.1
-      i += 1
-      retry
-    end
   end
 
   # tester should return true if the object is a leak

--- a/spec/zk/00_forked_client_integration_spec.rb
+++ b/spec/zk/00_forked_client_integration_spec.rb
@@ -23,9 +23,9 @@ describe 'forked client integration' do
     it %[should deliver callbacks in the child] do
       10.times do 
         ClientForker.run(@cnx_args, @base_path) do |forker|
-          forker.stat.should_not be_signaled
-          forker.stat.should be_exited
-          forker.stat.should be_success
+          expect(forker.stat).not_to be_signaled
+          expect(forker.stat).to be_exited
+          expect(forker.stat).to be_success
         end
       end
     end # should deliver callbacks in the child

--- a/spec/zk/client/locking_and_session_death_spec.rb
+++ b/spec/zk/client/locking_and_session_death_spec.rb
@@ -42,9 +42,9 @@ shared_examples_for 'session death' do
     deliver_session_event_to(zoo_state, @other_zk)
 
     # ditto, this is probably happening synchrnously
-    wait_until(2) { @a }.should be_true
+    expect(wait_until(2) { @a }).to be(true)
 
-    lambda { th.join(2) }.should raise_error(zoo_error_class)
+    expect { th.join(2) }.to raise_error(zoo_error_class)
   end
 end # session death
 

--- a/spec/zk/client_spec.rb
+++ b/spec/zk/client_spec.rb
@@ -21,7 +21,7 @@ describe ZK::Client::Threaded do
       it %[should do the right thing and not fail] do
         # this is an extra special case where the user obviously hates us
 
-        @zk.should be_kind_of(ZK::Client::Threaded) # yeah yeah, just be sure
+        expect(@zk).to be_kind_of(ZK::Client::Threaded) # yeah yeah, just be sure
 
         shutdown_thread = nil
 
@@ -31,12 +31,12 @@ describe ZK::Client::Threaded do
 
         wait_while { shutdown_thread.nil? }
 
-        shutdown_thread.should_not be_nil
-        shutdown_thread.should be_kind_of(Thread)
+        expect(shutdown_thread).not_to be_nil
+        expect(shutdown_thread).to be_kind_of(Thread)
 
-        shutdown_thread.join(5).should == shutdown_thread
+        expect(shutdown_thread.join(5)).to eq(shutdown_thread)
 
-        wait_until(5) { @zk.closed? }.should be_true
+        expect(wait_until(5) { @zk.closed? }).to be(true)
       end
     end
   end
@@ -53,15 +53,15 @@ describe ZK::Client::Threaded do
     end
 
     it %[should say the client is connected after reopen] do
-      @zk.connected?.should == true
+      expect(@zk.connected?).to eq(true)
 
       @zk.close!
 
-      @zk.connected?.should == false
+      expect(@zk.connected?).to eq(false)
 
       @zk.reopen
 
-      @zk.connected?.should == true
+      expect(@zk.connected?).to eq(true)
     end
   end
 
@@ -80,7 +80,7 @@ describe ZK::Client::Threaded do
       # TODO: this is a terrible test. there is no way to guarantee that this
       #       has been retried. the join at the end should not raise an error
 
-      @zk.should_not be_connected
+      expect(@zk).not_to be_connected
 
       th = Thread.new do
         @zk.stat('/path/to/blah', :retry_duration => 30)
@@ -89,11 +89,11 @@ describe ZK::Client::Threaded do
       th.run
 
       @zk.connect
-      th.join(5).should == th
+      expect(th.join(5)).to eq(th)
     end
 
     it %[barfs if the connection is closed before the connected event is received] do
-      @zk.should_not be_connected
+      expect(@zk).not_to be_connected
 
       exc = nil
 
@@ -110,14 +110,14 @@ describe ZK::Client::Threaded do
 
       @zk.close!
 
-      th.join(5).should == th
+      expect(th.join(5)).to eq(th)
 
-      exc.should_not be_nil
-      exc.should be_kind_of(ZK::Exceptions::Retryable)
+      expect(exc).not_to be_nil
+      expect(exc).to be_kind_of(ZK::Exceptions::Retryable)
     end
 
     it %[should barf if the timeout expires] do
-      @zk.should_not be_connected
+      expect(@zk).not_to be_connected
 
       exc = nil
 
@@ -132,10 +132,10 @@ describe ZK::Client::Threaded do
 
       th.run
 
-      th.join(5).should == th
+      expect(th.join(5)).to eq(th)
 
-      exc.should_not be_nil
-      exc.should be_kind_of(ZK::Exceptions::Retryable)
+      expect(exc).not_to be_nil
+      expect(exc).to be_kind_of(ZK::Exceptions::Retryable)
     end
   end
 end # ZK::Client::Threaded

--- a/spec/zk/election_spec.rb
+++ b/spec/zk/election_spec.rb
@@ -56,8 +56,8 @@ describe ZK::Election, :jruby => :broken do
           end
 
           @palin.on_losing_election do
-            @obama_won.should be_true
-            @palin.leader_acked?.should be_true
+            expect(@obama_won).to be(true)
+            expect(@palin.leader_acked?).to be(true)
             @palin_lost = true
           end
 
@@ -68,21 +68,21 @@ describe ZK::Election, :jruby => :broken do
           oth.run
 
           wait_until { @obama_waiting }
-          @obama_waiting.should be_true
+          expect(@obama_waiting).to be(true)
 
           # palin's callbacks haven't fired
-          @palin_lost.should be_nil
+          expect(@palin_lost).to be_nil
 
           latch.release
 
           wait_until { @obama_won }
-          @obama_won.should be_true
+          expect(@obama_won).to be(true)
 
-          lambda { oth.join(1).should == oth }.should_not raise_error
+          expect { expect(oth.join(1)).to eq(oth) }.not_to raise_error
 
           wait_until { @palin_lost }
 
-          @palin_lost.should be_true
+          expect(@palin_lost).to be(true)
         end
       end
 
@@ -120,45 +120,45 @@ describe ZK::Election, :jruby => :broken do
           @palin.vote!
 
           win_latch.await
-          @obama_won.should be_true
+          expect(@obama_won).to be(true)
 
           lose_latch.await
-          @palin_lost.should be_true
+          expect(@palin_lost).to be(true)
         end
 
         describe 'winner' do
           it %[should fire the on_winning_election callbacks] do
-            @obama_won.should be_true
+            expect(@obama_won).to be(true)
           end
 
           it %[should not fire the on_losing_election callbacks] do
-            @obama_lost.should be_nil
+            expect(@obama_lost).to be_nil
           end
 
           it %[should acknowledge completion of winning callbacks] do
-            @zk.exists?(@obama.leader_ack_path).should be_true
+            expect(@zk.exists?(@obama.leader_ack_path)).to be(true)
           end
 
           it %[should write its data to the leader_ack node] do
-            @zk.get(@obama.leader_ack_path).first.should == @data1
+            expect(@zk.get(@obama.leader_ack_path).first).to eq(@data1)
           end
 
           it %[should know it's the leader] do
-            @obama.should be_leader
+            expect(@obama).to be_leader
           end
         end
 
         describe 'loser' do # gets a talk show on Fox News? I KEED! I KEED!
           it %[should know it isn't the leader] do
-            @palin.should_not be_leader
+            expect(@palin).not_to be_leader
           end
 
           it %[should not fire the winning callbacks] do
-            @palin_won.should_not be_true
+            expect(@palin_won).not_to be(true)
           end
 
           it %[should fire the losing callbacks] do
-            @palin_lost.should be_true
+            expect(@palin_lost).to be(true)
           end
 
           it %[should take over as leader when the current leader goes away] do
@@ -167,13 +167,13 @@ describe ZK::Election, :jruby => :broken do
             @obama.zk.close!
             wait_until { @palin_won }
 
-            @palin_won.should be_true # god forbid
+            expect(@palin_won).to be(true) # god forbid
 
             wait_until { @zk2.exists?(@palin.leader_ack_path) }
 
-            @zk2.exists?(@palin.leader_ack_path).should be_true
+            expect(@zk2.exists?(@palin.leader_ack_path)).to be(true)
 
-            @zk2.get(@palin.leader_ack_path).first.should == @data2
+            expect(@zk2.get(@palin.leader_ack_path).first).to eq(@data2)
           end
 
           it %[should remain leader if the original leader comes back] do
@@ -193,9 +193,9 @@ describe ZK::Election, :jruby => :broken do
               newbama.vote!
               wait_until { newbama.voted? }
 
-              newbama.should be_voted
-              win_again.should be_false
-              newbama.should_not be_leader
+              expect(newbama).to be_voted
+              expect(win_again).to be(false)
+              expect(newbama).not_to be_leader
             end
           end
         end
@@ -207,12 +207,12 @@ describe ZK::Election, :jruby => :broken do
     before do
       @zk3 = ZK.new(*connection_args)
 
-      @zk3.exists?('/_zkelection/2012/leader_ack').should be_false
+      expect(@zk3.exists?('/_zkelection/2012/leader_ack')).to be(false)
 
       @obama = ZK::Election::Candidate.new(@zk, @election_name, :data => @data1)
       @palin = ZK::Election::Candidate.new(@zk2, @election_name, :data => @data2)
 
-      @zk3.exists?('/_zkelection/2012/leader_ack').should be_false
+      expect(@zk3.exists?('/_zkelection/2012/leader_ack')).to be(false)
 
       @observer = ZK::Election::Observer.new(@zk3, @election_name)
     end
@@ -231,17 +231,17 @@ describe ZK::Election, :jruby => :broken do
 
           @observer.observe!
           wait_until { !@observer.leader_alive.nil? }
-          @observer.leader_alive.should_not be_nil
-          @zk3.exists?(@observer.root_election_node).should be_false
+          expect(@observer.leader_alive).not_to be_nil
+          expect(@zk3.exists?(@observer.root_election_node)).to be(false)
         end
 
         it %[should set leader_alive to false] do
-          @observer.leader_alive.should be_false
+          expect(@observer.leader_alive).to be(false)
         end
 
         it %[should fire death callbacks] do
-          @events.length.should == 1
-          @events.first.should == :death
+          expect(@events.length).to eq(1)
+          expect(@events.first).to eq(:death)
         end
       end
 
@@ -263,19 +263,19 @@ describe ZK::Election, :jruby => :broken do
         end
 
         it %[should be obama that won] do
-          @obama.should be_leader
+          expect(@obama).to be_leader
         end
 
         it %[should be palin that lost] do
-          @palin.should_not be_leader
+          expect(@palin).not_to be_leader
         end
 
         it %[should set leader_alive to true] do
-          @observer.leader_alive.should be_true
+          expect(@observer.leader_alive).to be(true)
         end
 
         it %[should fire the new leader callbacks] do
-          @got_life_event.should be_true
+          expect(@got_life_event).to be(true)
         end
       end
 
@@ -286,7 +286,7 @@ describe ZK::Election, :jruby => :broken do
           wait_until { @obama.leader? }
 
           @palin.vote!
-          @palin.should_not be_leader
+          expect(@palin).not_to be_leader
 
           @got_life_event = @got_death_event = false
 
@@ -297,23 +297,23 @@ describe ZK::Election, :jruby => :broken do
 
           wait_until { !@observer.leader_alive.nil? }
 
-          @observer.leader_alive.should be_true
+          expect(@observer.leader_alive).to be(true)
           @zk.close!
           wait_until { !@zk.connected? && @palin.leader? && @palin.leader_acked? }
         end
 
         it %[should be palin who is leader] do
-          @palin.should be_leader
+          expect(@palin).to be_leader
         end
 
         it %[should have seen both the death and life events] do
           pending 'this test is flapping'
-          @got_life_event.should be_true
-          @got_death_event.should be_true
+          expect(@got_life_event).to be(true)
+          expect(@got_death_event).to be(true)
         end
 
         it %[should see the data of the new leader] do
-          @observer.leader_data.should == 'palin'
+          expect(@observer.leader_data).to eq('palin')
         end
       end
     end

--- a/spec/zk/election_spec.rb
+++ b/spec/zk/election_spec.rb
@@ -4,7 +4,7 @@ describe ZK::Election, :jruby => :broken do
   include_context 'connection opts'
 
   before do
-    ZK.open(connection_host) do |cnx| 
+    ZK.open(connection_host) do |cnx|
       logger.debug { "REMOVING /_zkelection" }
       cnx.rm_rf('/_zkelection')
     end
@@ -92,7 +92,7 @@ describe ZK::Election, :jruby => :broken do
           @obama_won = @obama_lost = @palin_won = @palin_lost = nil
           win_latch, lose_latch = Latch.new, Latch.new
 
-          @obama.on_winning_election do 
+          @obama.on_winning_election do
             logger.debug { "obama on_winning_election fired" }
             @obama_won = true
             win_latch.release
@@ -115,7 +115,7 @@ describe ZK::Election, :jruby => :broken do
             @palin_lost = true
             lose_latch.release
           end
-          
+
           @obama.vote!
           @palin.vote!
 

--- a/spec/zk/election_spec.rb
+++ b/spec/zk/election_spec.rb
@@ -307,7 +307,7 @@ describe ZK::Election, :jruby => :broken do
         end
 
         it %[should have seen both the death and life events] do
-          pending 'this test is flapping'
+          # pending 'this test is flapping'
           expect(@got_life_event).to be(true)
           expect(@got_death_event).to be(true)
         end

--- a/spec/zk/extensions_spec.rb
+++ b/spec/zk/extensions_spec.rb
@@ -6,8 +6,8 @@ module ZK
 
       it %[should not barf if backtrace is nil] do
         exc = StandardError.new
-        exc.backtrace.should be_nil
-        lambda { exc.to_std_format }.should_not raise_error
+        expect(exc.backtrace).to be_nil
+        expect { exc.to_std_format }.not_to raise_error
       end
     end
   end

--- a/spec/zk/locker/exclusive_locker_spec.rb
+++ b/spec/zk/locker/exclusive_locker_spec.rb
@@ -9,13 +9,13 @@ shared_examples_for 'ZK::Locker::ExclusiveLocker' do
 
     it %[should raise LockAssertionFailedError if there is an exclusive lock with a number lower than ours] do
       # this should *really* never happen
-      
+
       rlp = locker.root_lock_path
 
       zk.mkdir_p(rlp)
 
       bogus_path = zk.create("#{rlp}/#{ZK::Locker::EXCLUSIVE_LOCK_PREFIX}", :sequential => true, :ephemeral => true)
-      logger.debug { "bogus_path: #{bogus_path.inspect}" } 
+      logger.debug { "bogus_path: #{bogus_path.inspect}" }
 
       th = Thread.new do
         locker.lock(true)

--- a/spec/zk/locker/locker_basic_spec.rb
+++ b/spec/zk/locker/locker_basic_spec.rb
@@ -20,7 +20,7 @@ describe 'ZK::Client#locker' do
     @zk.close!
     @zk2.close!
     @zk3.close!
-    wait_until { @connections.all? { |c| c.closed? } } 
+    wait_until { @connections.all? { |c| c.closed? } }
   end
 
   it "should be able to acquire the lock if no one else is locking it" do

--- a/spec/zk/locker/locker_basic_spec.rb
+++ b/spec/zk/locker/locker_basic_spec.rb
@@ -24,43 +24,43 @@ describe 'ZK::Client#locker' do
   end
 
   it "should be able to acquire the lock if no one else is locking it" do
-    @zk.locker(@path_to_lock).lock.should be_true
+    expect(@zk.locker(@path_to_lock).lock).to be(true)
   end
 
   it "should not be able to acquire the lock if someone else is locking it" do
-    @zk.locker(@path_to_lock).lock.should be_true
-    @zk2.locker(@path_to_lock).lock.should be_false
+    expect(@zk.locker(@path_to_lock).lock).to be(true)
+    expect(@zk2.locker(@path_to_lock).lock).to be(false)
   end
 
   it "should assert properly if lock is acquired" do
-    @zk.locker(@path_to_lock).assert.should be_false
+    expect(@zk.locker(@path_to_lock).assert).to be(false)
     l = @zk2.locker(@path_to_lock)
-    l.lock.should be_true
-    l.assert.should be_true
+    expect(l.lock).to be(true)
+    expect(l.assert).to be(true)
   end
 
   it "should be able to acquire the lock after the first one releases it" do
     lock1 = @zk.locker(@path_to_lock)
     lock2 = @zk2.locker(@path_to_lock)
-    
-    lock1.lock.should be_true
-    lock2.lock.should be_false
+
+    expect(lock1.lock).to be(true)
+    expect(lock2.lock).to be(false)
     lock1.unlock
-    lock2.lock.should be_true
+    expect(lock2.lock).to be(true)
   end
 
   it "should be able to acquire the lock if the first locker goes away" do
     lock1 = @zk.locker(@path_to_lock)
     lock2 = @zk2.locker(@path_to_lock)
 
-    lock1.lock.should be_true
-    lock2.lock.should be_false
+    expect(lock1.lock).to be(true)
+    expect(lock2.lock).to be(false)
     @zk.close!
-    lock2.lock.should be_true
+    expect(lock2.lock).to be(true)
   end
 
   it "should be able to handle multi part path locks" do
-    @zk.locker("my/multi/part/path").lock.should be_true
+    expect(@zk.locker("my/multi/part/path").lock).to be(true)
   end
 
   describe :with_lock do
@@ -70,23 +70,23 @@ describe 'ZK::Client#locker' do
     describe 'Client::Conveniences' do
       it %[should yield the lock instance to the block] do
         @zk.with_lock(@path_to_lock) do |lock|
-          lock.should_not be_nil
-          lock.should be_kind_of(ZK::Locker::LockerBase)
-          lambda { lock.assert! }.should_not raise_error
+          expect(lock).not_to be_nil
+          expect(lock).to be_kind_of(ZK::Locker::LockerBase)
+          expect { lock.assert! }.not_to raise_error
         end
       end
 
       it %[should yield a shared lock when :mode => shared given] do
         @zk.with_lock(@path_to_lock, :mode => :shared) do |lock|
-          lock.should_not be_nil
-          lock.should be_kind_of(ZK::Locker::SharedLocker)
-          lambda { lock.assert! }.should_not raise_error
+          expect(lock).not_to be_nil
+          expect(lock).to be_kind_of(ZK::Locker::SharedLocker)
+          expect { lock.assert! }.not_to raise_error
         end
       end
 
       it %[should take a timeout] do
         first_lock = @zk.locker(@path_to_lock)
-        first_lock.lock.should be_true
+        expect(first_lock.lock).to be(true)
 
         thread = Thread.new do
           begin
@@ -98,8 +98,8 @@ describe 'ZK::Client#locker' do
           end
         end
 
-        thread.join(2).should == thread
-        @exc.should be_kind_of(ZK::Exceptions::LockWaitTimeoutError)
+        expect(thread.join(2)).to eq(thread)
+        expect(@exc).to be_kind_of(ZK::Exceptions::LockWaitTimeoutError)
       end
     end
 
@@ -107,26 +107,26 @@ describe 'ZK::Client#locker' do
       it "should blocking lock" do
         array = []
         first_lock = @zk.locker("mylock")
-        first_lock.lock.should be_true
+        expect(first_lock.lock).to be(true)
         array << :first_lock
 
         thread = Thread.new do
           @zk.locker("mylock").with_lock do
             array << :second_lock
           end
-          array.length.should == 2
+          expect(array.length).to eq(2)
         end
 
-        array.length.should == 1
+        expect(array.length).to eq(1)
         first_lock.unlock
         thread.join(10)
-        array.length.should == 2
+        expect(array.length).to eq(2)
       end
 
       it %[should accept a :wait option] do
         array = []
         first_lock = @zk.locker("mylock")
-        first_lock.lock.should be_true
+        expect(first_lock.lock).to be(true)
 
         second_lock = @zk.locker("mylock")
 
@@ -140,15 +140,15 @@ describe 'ZK::Client#locker' do
           end
         end
 
-        array.should be_empty
-        thread.join(2).should == thread
-        @exc.should_not be_nil
-        @exc.should be_kind_of(ZK::Exceptions::LockWaitTimeoutError)
+        expect(array).to be_empty
+        expect(thread.join(2)).to eq(thread)
+        expect(@exc).not_to be_nil
+        expect(@exc).to be_kind_of(ZK::Exceptions::LockWaitTimeoutError)
       end
 
       it "should interrupt a blocked lock" do
         first_lock = @zk.locker("mylock")
-        first_lock.lock.should be_true
+        expect(first_lock.lock).to be(true)
 
         second_lock = @zk.locker("mylock")
         thread = Thread.new do
@@ -165,7 +165,7 @@ describe 'ZK::Client#locker' do
 
         second_lock.interrupt!
         thread.join(2)
-        @exc.should be_kind_of(ZK::Exceptions::WakeUpException)
+        expect(@exc).to be_kind_of(ZK::Exceptions::WakeUpException)
       end
     end
   end # with_lock

--- a/spec/zk/locker/shared_exclusive_integration_spec.rb
+++ b/spec/zk/locker/shared_exclusive_integration_spec.rb
@@ -13,7 +13,7 @@ shared_examples_for :shared_exclusive_integration do
 
       mutex = Monitor.new
       cond = mutex.new_cond
-      
+
       th = Thread.new do
         logger.debug { "@ex_lock trying to acquire acquire lock" }
         @ex_lock.with_lock do
@@ -96,7 +96,7 @@ shared_examples_for :shared_exclusive_integration do
 
       mutex = Monitor.new
       cond = mutex.new_cond
-      
+
       th = Thread.new do
         logger.debug { "@ex_lock trying to acquire acquire lock" }
         @sh_lock.with_lock do

--- a/spec/zk/locker/shared_locker_spec.rb
+++ b/spec/zk/locker/shared_locker_spec.rb
@@ -9,17 +9,17 @@ shared_examples_for 'ZK::Locker::SharedLocker' do
 
     it %[should raise LockAssertionFailedError if there is an exclusive lock with a number lower than ours] do
       # this should *really* never happen
-      locker.lock.should be_true
+      expect(locker.lock).to be(true)
       shl_path = locker.lock_path
 
-      locker2.lock.should be_true
+      expect(locker2.lock).to be(true)
 
-      locker.unlock.should be_true
-      locker.should_not be_locked
+      expect(locker.unlock).to be(true)
+      expect(locker).not_to be_locked
 
-      zk.exists?(shl_path).should be_false
+      expect(zk.exists?(shl_path)).to be(false)
 
-      locker2.lock_path.should_not == shl_path
+      expect(locker2.lock_path).not_to eq(shl_path)
 
       # convert the first shared lock path into a exclusive one
 
@@ -27,7 +27,7 @@ shared_examples_for 'ZK::Locker::SharedLocker' do
 
       zk.create(exl_path, :ephemeral => true)
 
-      lambda { locker2.assert! }.should raise_error(ZK::Exceptions::LockAssertionFailedError)
+      expect { locker2.assert! }.to raise_error(ZK::Exceptions::LockAssertionFailedError)
     end
   end
 
@@ -35,18 +35,18 @@ shared_examples_for 'ZK::Locker::SharedLocker' do
     describe %[with default options] do
       it %[should work if the lock root doesn't exist] do
         zk.rm_rf(ZK::Locker.default_root_lock_node)
-        locker.should be_acquirable
+        expect(locker).to be_acquirable
       end
 
       it %[should check local state of lockedness] do
-        locker.lock.should be_true
-        locker.should be_acquirable
+        expect(locker.lock).to be(true)
+        expect(locker).to be_acquirable
       end
 
       it %[should check if any participants would prevent us from acquiring the lock] do
         ex_lock = ZK::Locker.exclusive_locker(zk, path)
-        ex_lock.lock.should be_true
-        locker.should_not be_acquirable
+        expect(ex_lock.lock).to be(true)
+        expect(locker).not_to be_acquirable
       end
     end
   end
@@ -59,13 +59,13 @@ shared_examples_for 'ZK::Locker::SharedLocker' do
       end
 
       it %[should acquire the first lock] do
-        @rval.should be_true
-        locker.should be_locked
+        expect(@rval).to be(true)
+        expect(locker).to be_locked
       end
 
       it %[should acquire the second lock] do
-        @rval2.should be_true
-        locker2.should be_locked
+        expect(@rval2).to be(true)
+        expect(locker2).to be_locked
       end
     end
 
@@ -77,11 +77,11 @@ shared_examples_for 'ZK::Locker::SharedLocker' do
       end
 
       it %[should return false] do
-        @rval.should be_false
+        expect(@rval).to be(false)
       end
 
       it %[should not be locked] do
-        locker.should_not be_locked
+        expect(locker).not_to be_locked
       end
     end
 
@@ -96,7 +96,7 @@ shared_examples_for 'ZK::Locker::SharedLocker' do
         it %[should acquire the lock after the write lock is released old-style] do
           ary = []
 
-          locker.lock.should be_false
+          expect(locker.lock).to be(false)
 
           th = Thread.new do
             locker.lock(true)
@@ -104,24 +104,24 @@ shared_examples_for 'ZK::Locker::SharedLocker' do
           end
 
           locker.wait_until_blocked(5)
-          locker.should be_waiting
-          locker.should_not be_locked
-          ary.should be_empty
+          expect(locker).to be_waiting
+          expect(locker).not_to be_locked
+          expect(ary).to be_empty
 
           zk.delete(@write_lock_path)
 
-          th.join(2).should == th
+          expect(th.join(2)).to eq(th)
 
-          ary.should_not be_empty
-          ary.length.should == 1
+          expect(ary).not_to be_empty
+          expect(ary.length).to eq(1)
 
-          locker.should be_locked
+          expect(locker).to be_locked
         end
 
         it %[should acquire the lock after the write lock is released new-style] do
           ary = []
 
-          locker.lock.should be_false
+          expect(locker.lock).to be(false)
 
           th = Thread.new do
             locker.lock(:wait => true)
@@ -129,18 +129,18 @@ shared_examples_for 'ZK::Locker::SharedLocker' do
           end
 
           locker.wait_until_blocked(5)
-          locker.should be_waiting
-          locker.should_not be_locked
-          ary.should be_empty
+          expect(locker).to be_waiting
+          expect(locker).not_to be_locked
+          expect(ary).to be_empty
 
           zk.delete(@write_lock_path)
 
-          th.join(2).should == th
+          expect(th.join(2)).to eq(th)
 
-          ary.should_not be_empty
-          ary.length.should == 1
+          expect(ary).not_to be_empty
+          expect(ary.length).to eq(1)
 
-          locker.should be_locked
+          expect(locker).to be_locked
         end
       end
 
@@ -150,9 +150,9 @@ shared_examples_for 'ZK::Locker::SharedLocker' do
 
           write_lock_dir = File.dirname(@write_lock_path)
 
-          zk.children(write_lock_dir).length.should == 1
+          expect(zk.children(write_lock_dir).length).to eq(1)
 
-          locker.lock.should be_false
+          expect(locker.lock).to be(false)
 
           th = Thread.new do
             begin
@@ -164,16 +164,16 @@ shared_examples_for 'ZK::Locker::SharedLocker' do
           end
 
           locker.wait_until_blocked(5)
-          locker.should be_waiting
-          locker.should_not be_locked
-          ary.should be_empty
+          expect(locker).to be_waiting
+          expect(locker).not_to be_locked
+          expect(ary).to be_empty
 
-          th.join(2).should == th
+          expect(th.join(2)).to eq(th)
 
-          zk.children(write_lock_dir).length.should == 1
+          expect(zk.children(write_lock_dir).length).to eq(1)
 
-          ary.should be_empty
-          @exc.should be_kind_of(ZK::Exceptions::LockWaitTimeoutError)
+          expect(ary).to be_empty
+          expect(@exc).to be_kind_of(ZK::Exceptions::LockWaitTimeoutError)
         end
 
       end

--- a/spec/zk/locker_spec.rb
+++ b/spec/zk/locker_spec.rb
@@ -14,9 +14,9 @@ describe ZK::Locker do
 
       ZK::Locker.cleanup(@zk)
 
-      lambda { locker.assert! }.should_not raise_error
+      expect { locker.assert! }.not_to raise_error
 
-      bogus_lock_dir_names.each { |n| @zk.stat("#{ZK::Locker.default_root_lock_node}/#{n}").should_not exist }
+      bogus_lock_dir_names.each { |n| expect(@zk.stat("#{ZK::Locker.default_root_lock_node}/#{n}")).not_to exist }
 
     end
   end

--- a/spec/zk/module_spec.rb
+++ b/spec/zk/module_spec.rb
@@ -21,7 +21,7 @@ describe ZK do
 
     describe %[with a chrooted connection string and a :chroot => '/path'] do
       it %[should raise an ArgumentError] do
-        lambda { @zk = ZK.new("#{connection_host}/zktest", :chroot => '/zktest') }.should raise_error(ArgumentError)
+        expect { @zk = ZK.new("#{connection_host}/zktest", :chroot => '/zktest') }.to raise_error(ArgumentError)
       end
     end
 
@@ -29,7 +29,7 @@ describe ZK do
       before { @zk = ZK.new }
 
       it %[should create a default connection] do
-        @zk.should be_connected
+        expect(@zk).to be_connected
       end
     end
 
@@ -54,10 +54,10 @@ describe ZK do
           before { @zk = ZK.new(:chroot => chroot_path) }
 
           it %[should use the default connection string, create the chroot and return the connection] do
-            @zk.exists?('/').should be_true
+            expect(@zk.exists?('/')).to be(true)
             @zk.create('/blah', 'data')
 
-            @unchroot.get("#{chroot_path}/blah").first.should == 'data'
+            expect(@unchroot.get("#{chroot_path}/blah").first).to eq('data')
           end
         end
 
@@ -69,10 +69,10 @@ describe ZK do
             end
 
             it %[should create the chroot path and then return the connection] do
-              @zk.exists?('/').should be_true
+              expect(@zk.exists?('/')).to be(true)
               @zk.create('/blah', 'data')
 
-              @unchroot.get("#{chroot_path}/blah").first.should == 'data'
+              expect(@unchroot.get("#{chroot_path}/blah").first).to eq('data')
             end
           end
 
@@ -82,26 +82,26 @@ describe ZK do
             end
 
             it %[should create the chroot path and then return the connection] do
-              @zk.exists?('/').should be_true
+              expect(@zk.exists?('/')).to be(true)
               @zk.create('/blah', 'data')
 
-              @unchroot.get("#{chroot_path}/blah").first.should == 'data'
+              expect(@unchroot.get("#{chroot_path}/blah").first).to eq('data')
             end
           end
 
           describe %[and :chroot => :check] do
             it %[should barf with a ChrootPathDoesNotExistError] do
-              lambda do
+              expect do
                 # assign in case of a bug, that way this connection will get torn down
                 @zk = ZK.new("#{connection_host}#{chroot_path}", :chroot => :check)
-              end.should raise_error(ZK::Exceptions::ChrootPathDoesNotExistError)
+              end.to raise_error(ZK::Exceptions::ChrootPathDoesNotExistError)
             end
           end
 
           describe %[and :chroot => :do_nothing] do
             it %[should return a connection in a weird state] do
               @zk = ZK.new("#{connection_host}#{chroot_path}", :chroot => :do_nothing)
-              lambda { @zk.get('/') }.should raise_error(ZK::Exceptions::NoNode)
+              expect { @zk.get('/') }.to raise_error(ZK::Exceptions::NoNode)
             end
           end
 
@@ -109,10 +109,10 @@ describe ZK do
             before { @zk = ZK.new(connection_host, :chroot => chroot_path) }
 
             it %[should create the chroot path and then return the connection] do
-              @zk.exists?('/').should be_true
+              expect(@zk.exists?('/')).to be(true)
               @zk.create('/blah', 'data')
 
-              @unchroot.get("#{chroot_path}/blah").first.should == 'data'
+              expect(@unchroot.get("#{chroot_path}/blah").first).to eq('data')
             end
           end
         end # as a connection string
@@ -125,10 +125,10 @@ describe ZK do
           before { @zk = ZK.new(:chroot => chroot_path) }
 
           it %[should use the default connection string and totally work] do
-            @zk.exists?('/').should be_true
+            expect(@zk.exists?('/')).to be(true)
             @zk.create('/blah', 'data')
 
-            @unchroot.get("#{chroot_path}/blah").first.should == 'data'
+            expect(@unchroot.get("#{chroot_path}/blah").first).to eq('data')
           end
         end
 
@@ -139,10 +139,10 @@ describe ZK do
             end
 
             it %[should totally work] do
-              @zk.exists?('/').should be_true
+              expect(@zk.exists?('/')).to be(true)
               @zk.create('/blah', 'data')
 
-              @unchroot.get("#{chroot_path}/blah").first.should == 'data'
+              expect(@unchroot.get("#{chroot_path}/blah").first).to eq('data')
             end
           end
 
@@ -152,26 +152,26 @@ describe ZK do
             end
 
             it %[should totally work] do
-              @zk.exists?('/').should be_true
+              expect(@zk.exists?('/')).to be(true)
               @zk.create('/blah', 'data')
 
-              @unchroot.get("#{chroot_path}/blah").first.should == 'data'
+              expect(@unchroot.get("#{chroot_path}/blah").first).to eq('data')
             end
           end
 
           describe %[and :chroot => :check] do
             it %[should totally work] do
-              lambda do
+              expect do
                 # assign in case of a bug, that way this connection will get torn down
                 @zk = ZK.new("#{connection_host}#{chroot_path}", :chroot => :check)
-              end.should_not raise_error
+              end.not_to raise_error
             end
           end
 
           describe %[and :chroot => :do_nothing] do
             it %[should totally work] do
               @zk = ZK.new("#{connection_host}#{chroot_path}", :chroot => :do_nothing)
-              lambda { @zk.get('/') }.should_not raise_error
+              expect { @zk.get('/') }.not_to raise_error
             end
           end
 
@@ -179,10 +179,10 @@ describe ZK do
             before { @zk = ZK.new(connection_host, :chroot => chroot_path) }
 
             it %[should totally work] do
-              @zk.exists?('/').should be_true
+              expect(@zk.exists?('/')).to be(true)
               @zk.create('/blah', 'data')
 
-              @unchroot.get("#{chroot_path}/blah").first.should == 'data'
+              expect(@unchroot.get("#{chroot_path}/blah").first).to eq('data')
             end
           end
         end # as a connection string

--- a/spec/zk/module_spec.rb
+++ b/spec/zk/module_spec.rb
@@ -187,7 +187,7 @@ describe ZK do
           end
         end # as a connection string
       end # that exists
-    end # with a chroot 
+    end # with a chroot
   end # :new
 end # ZK
 

--- a/spec/zk/node_deletion_watcher_spec.rb
+++ b/spec/zk/node_deletion_watcher_spec.rb
@@ -15,18 +15,18 @@ describe ZK::NodeDeletionWatcher do
       @zk.mkdir_p(@path)
 
       th = Thread.new { @n.block_until_deleted }
-      
-      @n.wait_until_blocked(5).should be_true
+
+      expect(@n.wait_until_blocked(5)).to be(true)
 
       logger.debug { "wait_until_blocked returned" }
 
-      @n.should be_blocked
+      expect(@n).to be_blocked
 
       @zk.rm_rf(@path)
 
-      th.join(5).should == th
-      @n.should_not be_blocked
-      @n.should be_done
+      expect(th.join(5)).to eq(th)
+      expect(@n).not_to be_blocked
+      expect(@n).to be_done
     end
 
     it %[should wake up if interrupt! is called] do
@@ -43,12 +43,12 @@ describe ZK::NodeDeletionWatcher do
 
       @n.wait_until_blocked(5)
 
-      @n.should be_blocked
+      expect(@n).to be_blocked
 
       @n.interrupt!
-      th.join(5).should == th
+      expect(th.join(5)).to eq(th)
 
-      @exc.should be_kind_of(ZK::Exceptions::WakeUpException)
+      expect(@exc).to be_kind_of(ZK::Exceptions::WakeUpException)
     end
 
     it %[should raise LockWaitTimeoutError if we time out waiting for a node to be deleted] do
@@ -62,28 +62,28 @@ describe ZK::NodeDeletionWatcher do
         end
       end
 
-      @n.wait_until_blocked(5).should be_true
+      expect(@n.wait_until_blocked(5)).to be(true)
 
       logger.debug { "wait_until_blocked returned" }
 
-      th.join(5).should == th
-      
-      @exc.should be_kind_of(ZK::Exceptions::LockWaitTimeoutError)
-      @n.should be_done
-      @n.should be_timed_out
+      expect(th.join(5)).to eq(th)
+
+      expect(@exc).to be_kind_of(ZK::Exceptions::LockWaitTimeoutError)
+      expect(@n).to be_done
+      expect(@n).to be_timed_out
     end
   end
 
   describe %[when the node doesn't exist] do
     it %[should not block the caller and be done] do
-      @zk.exists?(@path).should be_false
+      expect(@zk.exists?(@path)).to be(false)
 
       th = Thread.new { @n.block_until_deleted }
 
       @n.wait_until_blocked
-      @n.should_not be_blocked
-      th.join(5).should == th
-      @n.should be_done
+      expect(@n).not_to be_blocked
+      expect(th.join(5)).to eq(th)
+      expect(@n).to be_done
     end
   end
 
@@ -140,23 +140,27 @@ describe ZK::NodeDeletionWatcher do
       runner.run
       controller.run
       controller.join
-      runner.join(5).should == runner
-      watcher.should be_done
+      expect(runner.join(5)).to eq(runner)
+      expect(watcher).to be_done
     end
 
     context %[threshold not supplied] do
       let(:watcher_params){}
 
       it 'should raise' do
-        expect{ watcher }.to_not raise_exception
+        expect{ watcher }.to_not raise_error
       end
-      its(:threshold){ should be_zero }
+
+      describe '#threshold' do
+        subject { super().threshold }
+        it { should be_zero }
+      end
     end
 
     context %[invalid threshold given] do
       let(:watcher_params){ {:threshold => :foo} }
       it 'should raise' do
-        expect{ watcher }.to raise_exception
+        expect{ watcher }.to raise_error(ZK::Exceptions::BadArguments)
       end
     end
 
@@ -168,10 +172,14 @@ describe ZK::NodeDeletionWatcher do
           runner.run
           controller.run
           controller.join
-          runner.join(5).should == runner
-          watcher.should be_done
+          expect(runner.join(5)).to eq(runner)
+          expect(watcher).to be_done
         end
-        its(:threshold){ should == 1 }
+
+        describe '#threshold' do
+          subject { super().threshold }
+          it { should == 1 }
+        end
       end
 
       context do
@@ -181,10 +189,10 @@ describe ZK::NodeDeletionWatcher do
           runner.run
           controller.run
           controller.join
-          runner.join(5).should == runner
-          @exc.should be_kind_of(ZK::Exceptions::LockWaitTimeoutError)
-          watcher.should be_done
-          watcher.should be_timed_out
+          expect(runner.join(5)).to eq(runner)
+          expect(@exc).to be_kind_of(ZK::Exceptions::LockWaitTimeoutError)
+          expect(watcher).to be_done
+          expect(watcher).to be_timed_out
         end
       end
     end

--- a/spec/zk/pool_spec.rb
+++ b/spec/zk/pool_spec.rb
@@ -8,7 +8,7 @@ describe ZK::Pool do
       report_realtime('opening pool') do
         @pool_size = 2
         @connection_pool = ZK::Pool::Simple.new(connection_host, @pool_size, :watcher => :default)
-        @connection_pool.should be_open
+        expect(@connection_pool).to be_open
       end
     end
 
@@ -22,7 +22,7 @@ describe ZK::Pool do
           unless th.join(5) == th
             logger.warn { "Forcing pool closed!" }
             @connection_pool.force_close!
-            th.join(5).should == th
+            expect(th.join(5)).to eq(th)
           end
         end
       end
@@ -40,7 +40,7 @@ describe ZK::Pool do
     it "should allow you to execute commands on a connection" do
       @connection_pool.with_connection do |zk|
         zk.create("/test_pool", "", :mode => :ephemeral)
-        zk.exists?("/test_pool").should be_true
+        expect(zk.exists?("/test_pool")).to be(true)
       end
     end
 
@@ -48,7 +48,7 @@ describe ZK::Pool do
       it %[should allow you to execute commands on the connection pool itself] do
         @connection_pool.create('/test_pool', '', :mode => :persistent)
         wait_until(2) { @connection_pool.exists?('/test_pool') }
-        @connection_pool.exists?('/test_pool').should be_true
+        expect(@connection_pool.exists?('/test_pool')).to be(true)
       end
     end
 
@@ -74,30 +74,30 @@ describe ZK::Pool do
           @cond.wait(@mutex) while @cnx.nil?
         end
 
-        @cnx.should_not be_nil
+        expect(@cnx).not_to be_nil
 
         closing_th = Thread.new do
           @connection_pool.close_all!
         end
 
         wait_until(5) { @connection_pool.closing? }
-        @connection_pool.should be_closing
+        expect(@connection_pool).to be_closing
         logger.debug { "connection pool is closing" }
 
-        lambda { @connection_pool.with_connection { |c| c } }.should raise_error(ZK::Exceptions::PoolIsShuttingDownException)
+        expect { @connection_pool.with_connection { |c| c } }.to raise_error(ZK::Exceptions::PoolIsShuttingDownException)
 
         latch.release
 
-        open_th.join(5).should == open_th
+        expect(open_th.join(5)).to eq(open_th)
 
         @connection_pool.wait_until_closed
 
-        @connection_pool.should be_closed
+        expect(@connection_pool).to be_closed
 
-        lambda do
-          closing_th.join(1).should == closing_th
-          open_th.join(1).should == open_th
-        end.should_not raise_error
+        expect do
+          expect(closing_th.join(1)).to eq(closing_th)
+          expect(open_th.join(1)).to eq(open_th)
+        end.not_to raise_error
       end
     end
 
@@ -109,7 +109,7 @@ describe ZK::Pool do
           @cnx << @connection_pool.checkout
         end
 
-        @cnx.length.should_not be_zero
+        expect(@cnx.length).not_to be_zero
 
         # this exc nonsense is because 1.8.7's scheduler is broken
         @exc = nil
@@ -129,8 +129,8 @@ describe ZK::Pool do
 
         @connection_pool.wait_until_closed
 
-        th.join(5).should == th
-        @exc.should be_kind_of(ZK::Exceptions::PoolIsShuttingDownException)
+        expect(th.join(5)).to eq(th)
+        expect(@exc).to be_kind_of(ZK::Exceptions::PoolIsShuttingDownException)
       end
     end
 
@@ -150,19 +150,19 @@ describe ZK::Pool do
         zk.watcher.register(@path) do |event|
 
           @callback_called = true
-          event.path.should == @path
+          expect(event.path).to eq(@path)
         end
 
-        zk.exists?(@path, :watch => true).should be_false
+        expect(zk.exists?(@path, :watch => true)).to be(false)
       end
 
       @connection_pool.with_connection do |zk|
-        zk.create(@path, "", :mode => :ephemeral).should == @path
+        expect(zk.create(@path, "", :mode => :ephemeral)).to eq(@path)
       end
 
       wait_until(1) { @callback_called }
 
-      @callback_called.should be_true
+      expect(@callback_called).to be(true)
     end
 
     # These tests are seriously yucky, but they show that when a client is !connected?
@@ -171,42 +171,38 @@ describe ZK::Pool do
     describe 'health checking with disconnected client', :rbx => :broken do
       before do
         wait_until(2) { @connection_pool.available_size == 2 }
-        @connection_pool.available_size.should == 2
+        expect(@connection_pool.available_size).to eq(2)
 
         @connections = @connection_pool.connections
-        @connections.length.should == 2
+        expect(@connections.length).to eq(2)
 
         @cnx1 = @connections.shift
 
-        mock_sub = flexmock(:subscription)
+        mock_sub = double(:subscription)
 
-        @mcnx1 = flexmock(@cnx1) do |m|
-          m.should_receive(:connected?).at_least.once.and_return(false)
-          m.should_receive(:on_connected).with(Proc).at_least.once.and_return(mock_sub)
-        end
+        expect(@cnx1).to receive(:connected?).at_least(1).and_return(false)
+        expect(@cnx1).to receive(:on_connected).at_least(1).and_yield.and_return(mock_sub)
 
-        @connections.unshift(@mcnx1)
+        @connections.unshift(@cnx1)
       end
 
       after do
-        @connections.delete(@mcnx1)
-        @connections.unshift(@cnx1)
         [@cnx1, @cnx2].each { |c| @connection_pool.checkin(c) }
       end
 
       it %[should remove the disconnected client from the pool] do
-        @connection_pool.available_size.should == 2
+        expect(@connection_pool.available_size).to eq(2)
 
         @cnx2 = @connection_pool.checkout
 
         # this is gross and relies on knowing internal state
-        @connection_pool.checkout(false).should be_false
+        expect(@connection_pool.checkout(false)).to be(false)
 
-        @cnx2.should_not be_nil
-        @cnx2.should_not == @mcnx1
+        expect(@cnx2).not_to be_nil
+        expect(@cnx2).not_to eq(@cnx1)
 
-        @connection_pool.available_size.should == 0
-        @connections.should include(@mcnx1)
+        expect(@connection_pool.available_size).to eq(0)
+        expect(@connections).to include(@cnx1)
       end
     end
   end # Simple
@@ -219,18 +215,18 @@ describe ZK::Pool do
       @max_clients = 2
       @timeout = 10
       @connection_pool = ZK::Pool::Bounded.new(connection_host, :min_clients => @min_clients, :max_clients => @max_clients, :timeout => @timeout)
-      @connection_pool.should be_open
+      expect(@connection_pool).to be_open
       wait_until(2) { @connection_pool.available_size > 0 }
     end
 
     after do
       @connection_pool.force_close! unless @connection_pool.closed?
-      @connection_pool.should be_closed
+      expect(@connection_pool).to be_closed
     end
 
     describe 'initial state' do
       it %[should have initialized the minimum number of clients] do
-        @connection_pool.size.should == @min_clients
+        expect(@connection_pool.size).to eq(@min_clients)
       end
     end
 
@@ -246,22 +242,22 @@ describe ZK::Pool do
 
       it %[should grow if it can] do
         wait_until(2) { @connection_pool.available_size > 0 }
-        @connection_pool.available_size.should > 0
+        expect(@connection_pool.available_size > 0).to be(true)
 
-        @connection_pool.size.should == 1
+        expect(@connection_pool.size).to eq(1)
 
         logger.debug { "checking out @cnx1" }
         @cnx1 = @connection_pool.checkout
-        @cnx1.should_not be_false
+        expect(@cnx1).not_to be(false)
 
-        @connection_pool.can_grow_pool?.should be_true
+        expect(@connection_pool.can_grow_pool?).to be(true)
 
         logger.debug { "checking out @cnx2" }
         @cnx2 = @connection_pool.checkout
-        @cnx2.should_not be_false
-        @cnx2.should be_connected
+        expect(@cnx2).not_to be(false)
+        expect(@cnx2).to be_connected
 
-        @cnx1.object_id.should_not == @cnx2.object_id
+        expect(@cnx1.object_id).not_to eq(@cnx2.object_id)
 
         [@cnx1, @cnx2].each { |c| @connection_pool.checkin(c) }
       end
@@ -270,14 +266,14 @@ describe ZK::Pool do
         lose_q = Queue.new
 
         @cnx1 = @connection_pool.checkout
-        @cnx1.should_not be_false
+        expect(@cnx1).not_to be(false)
 
-        @connection_pool.can_grow_pool?.should be_true
+        expect(@connection_pool.can_grow_pool?).to be(true)
 
         @cnx2 = @connection_pool.checkout
-        @cnx2.should_not be_false
+        expect(@cnx2).not_to be(false)
 
-        @connection_pool.can_grow_pool?.should be_false
+        expect(@connection_pool.can_grow_pool?).to be(false)
 
         logger.debug { "spawning losing thread" }
 
@@ -294,22 +290,22 @@ describe ZK::Pool do
         # logger.debug { "count waiters: #{@connection_pool.count_waiters}" }
         # @connection_pool.count_waiters.should == 1
 
-        loser[:cnx].should be_nil
+        expect(loser[:cnx]).to be_nil
 
         [@cnx1, @cnx2].each { |c| @connection_pool.checkin(c) }
 
         loser.join_until(2) { loser[:cnx] }
-        loser[:cnx].should_not be_nil
+        expect(loser[:cnx]).not_to be_nil
 
         lose_q.enq(:release)
 
-        lambda { loser.join(2).should == loser }.should_not raise_error
+        expect { expect(loser.join(2)).to eq(loser) }.not_to raise_error
 
         logger.debug { "joined losing thread" }
 
-        @connection_pool.count_waiters.should be_zero
-        @connection_pool.available_size.should == 2
-        @connection_pool.size.should == 2
+        expect(@connection_pool.count_waiters).to be_zero
+        expect(@connection_pool.available_size).to eq(2)
+        expect(@connection_pool.size).to eq(2)
       end
     end   # should grow to max_clients
 

--- a/spec/zk/pool_spec.rb
+++ b/spec/zk/pool_spec.rb
@@ -54,8 +54,6 @@ describe ZK::Pool do
 
     describe :close_all! do
       it %[should shutdown gracefully] do
-        release_q  = Queue.new
-
         latch = Latch.new
 
         @about_to_block = false
@@ -269,10 +267,7 @@ describe ZK::Pool do
       end
 
       it %[should not grow past max_clients and block] do
-        win_q = Queue.new
         lose_q = Queue.new
-
-        threads = []
 
         @cnx1 = @connection_pool.checkout
         @cnx1.should_not be_false

--- a/spec/zk/pool_spec.rb
+++ b/spec/zk/pool_spec.rb
@@ -112,7 +112,7 @@ describe ZK::Pool do
         end
 
         @cnx.length.should_not be_zero
-        
+
         # this exc nonsense is because 1.8.7's scheduler is broken
         @exc = nil
 
@@ -143,7 +143,7 @@ describe ZK::Pool do
 
       @connection_pool.with_connection do |zk|
         begin
-          zk.delete(@path) 
+          zk.delete(@path)
         rescue ZK::Exceptions::NoNode
         end
       end
@@ -169,7 +169,7 @@ describe ZK::Pool do
 
     # These tests are seriously yucky, but they show that when a client is !connected?
     # the pool behaves properly and will not return that client to the caller.
-    
+
     describe 'health checking with disconnected client', :rbx => :broken do
       before do
         wait_until(2) { @connection_pool.available_size == 2 }
@@ -200,7 +200,7 @@ describe ZK::Pool do
         @connection_pool.available_size.should == 2
 
         @cnx2 = @connection_pool.checkout
-        
+
         # this is gross and relies on knowing internal state
         @connection_pool.checkout(false).should be_false
 

--- a/spec/zk/threaded_callback_spec.rb
+++ b/spec/zk/threaded_callback_spec.rb
@@ -17,11 +17,11 @@ describe ZK::ThreadedCallback do
   end
 
   after do
-    @tcb.shutdown.should be_true
+    expect(@tcb.shutdown).to be(true)
   end
 
   it %[should have started the thread] do
-    @tcb.should be_alive
+    expect(@tcb).to be_alive
   end
 
   describe %[pausing for fork] do
@@ -31,19 +31,19 @@ describe ZK::ThreadedCallback do
       end
 
       it %[should stop the thread] do
-        @tcb.should_not be_alive
+        expect(@tcb).not_to be_alive
       end
 
       it %[should allow calls] do
-        lambda { @tcb.call(:a) }.should_not raise_error
+        expect { @tcb.call(:a) }.not_to raise_error
       end
     end
 
     describe %[when not running] do
       it %[should barf with InvalidStateError] do
-        @tcb.shutdown.should be_true
-        @tcb.should_not be_alive
-        lambda { @tcb.pause_before_fork_in_parent }.should raise_error(ZK::Exceptions::InvalidStateError)
+        expect(@tcb.shutdown).to be(true)
+        expect(@tcb).not_to be_alive
+        expect { @tcb.pause_before_fork_in_parent }.to raise_error(ZK::Exceptions::InvalidStateError)
       end
     end
   end
@@ -52,7 +52,7 @@ describe ZK::ThreadedCallback do
     describe %[after pause] do
       before do
         @tcb.pause_before_fork_in_parent
-        @tcb.should_not be_alive
+        expect(@tcb).not_to be_alive
       end
 
       it %[should deliver any calls on resume] do
@@ -65,13 +65,13 @@ describe ZK::ThreadedCallback do
 
         wait_until { @called.length >= 2 }
 
-        @called.length.should >= 2
+        expect(@called.length).to be >= 2
       end
     end
 
     describe %[if not paused] do
       it %[should barf with InvalidStateError] do
-        lambda { @tcb.resume_after_fork_in_parent }.should raise_error(ZK::Exceptions::InvalidStateError)
+        expect { @tcb.resume_after_fork_in_parent }.to raise_error(ZK::Exceptions::InvalidStateError)
       end
     end
   end

--- a/spec/zk/threadpool_spec.rb
+++ b/spec/zk/threadpool_spec.rb
@@ -48,7 +48,7 @@ describe ZK::Threadpool do
       @ary = []
 
       @threadpool.on_exception { |exc| @ary << exc }
-        
+
       @threadpool.defer { raise "ZOMG!" }
 
       wait_while(2) { @ary.empty? }
@@ -78,7 +78,7 @@ describe ZK::Threadpool do
 
       @rval = nil
 
-      @threadpool.defer do 
+      @threadpool.defer do
         @rval = true
       end
 

--- a/spec/zk/threadpool_spec.rb
+++ b/spec/zk/threadpool_spec.rb
@@ -11,11 +11,11 @@ describe ZK::Threadpool do
 
   describe :new do
     it %[should be running] do
-      @threadpool.should be_running
+      expect(@threadpool).to be_running
     end
 
     it %[should use the default size] do
-      @threadpool.size.should == ZK::Threadpool.default_size
+      expect(@threadpool.size).to eq(ZK::Threadpool.default_size)
     end
   end
 
@@ -27,19 +27,19 @@ describe ZK::Threadpool do
 
       wait_until(2) { @th }
 
-      @th.should_not == Thread.current
+      expect(@th).not_to eq(Thread.current)
     end
 
     it %[should barf if the argument is not callable] do
-      bad_obj = flexmock(:not_callable)
-      bad_obj.should_not respond_to(:call)
+      bad_obj = double(:not_callable)
+      expect(bad_obj).not_to respond_to(:call)
 
-      lambda { @threadpool.defer(bad_obj) }.should raise_error(ArgumentError)
+      expect { @threadpool.defer(bad_obj) }.to raise_error(ArgumentError)
     end
 
     it %[should not barf if the threadpool is not running] do
       @threadpool.shutdown
-      lambda { @threadpool.defer { "hai!" } }.should_not raise_error
+      expect { @threadpool.defer { "hai!" } }.not_to raise_error
     end
   end
 
@@ -53,28 +53,28 @@ describe ZK::Threadpool do
 
       wait_while(2) { @ary.empty? }
 
-      @ary.length.should == 1
+      expect(@ary.length).to eq(1)
 
       e = @ary.shift
 
-      e.should be_kind_of(RuntimeError)
-      e.message.should == 'ZOMG!'
+      expect(e).to be_kind_of(RuntimeError)
+      expect(e.message).to eq('ZOMG!')
     end
   end
 
   describe :shutdown do
     it %[should set running to false] do
       @threadpool.shutdown
-      @threadpool.should_not be_running
+      expect(@threadpool).not_to be_running
     end
   end
 
   describe :start! do
     it %[should be able to start a threadpool that had previously been shutdown (reuse)] do
       @threadpool.shutdown
-      @threadpool.start!.should be_true
+      expect(@threadpool.start!).to be(true)
 
-      @threadpool.should be_running
+      expect(@threadpool).to be_running
 
       @rval = nil
 
@@ -83,7 +83,7 @@ describe ZK::Threadpool do
       end
 
       wait_until(2) { @rval }
-      @rval.should be_true
+      expect(@rval).to be(true)
     end
   end
 
@@ -93,24 +93,24 @@ describe ZK::Threadpool do
       @threadpool.defer { @a << @threadpool.on_threadpool? }
 
       wait_while(2) { @a.empty? }
-      @a.should_not be_empty
+      expect(@a).not_to be_empty
 
-      @a.first.should be_true
+      expect(@a.first).to be(true)
     end
   end
 
   describe :pause_before_fork_in_parent do
     it %[should stop all running threads] do
-      @threadpool.should be_running
-      @threadpool.should be_alive
+      expect(@threadpool).to be_running
+      expect(@threadpool).to be_alive
       @threadpool.pause_before_fork_in_parent
 
-      @threadpool.should_not be_alive
+      expect(@threadpool).not_to be_alive
     end
 
     it %[should raise InvalidStateError if already paused] do
       @threadpool.pause_before_fork_in_parent
-      lambda { @threadpool.pause_before_fork_in_parent }.should raise_error(ZK::Exceptions::InvalidStateError)
+      expect { @threadpool.pause_before_fork_in_parent }.to raise_error(ZK::Exceptions::InvalidStateError)
     end
   end
 
@@ -121,12 +121,12 @@ describe ZK::Threadpool do
 
     it %[should start all threads running again] do
       @threadpool.resume_after_fork_in_parent
-      @threadpool.should be_alive
+      expect(@threadpool).to be_alive
     end
 
     it %[should raise InvalidStateError if not in paused state] do
       @threadpool.shutdown
-      lambda { @threadpool.resume_after_fork_in_parent }.should raise_error(ZK::Exceptions::InvalidStateError)
+      expect { @threadpool.resume_after_fork_in_parent }.to raise_error(ZK::Exceptions::InvalidStateError)
     end
 
     it %[should run callbacks deferred while paused] do
@@ -147,7 +147,7 @@ describe ZK::Threadpool do
 
       latch.await(2)
 
-      calls.should_not be_empty
+      expect(calls).not_to be_empty
     end
   end
 end

--- a/spec/zk/watch_spec.rb
+++ b/spec/zk/watch_spec.rb
@@ -17,7 +17,7 @@ describe ZK do
     after do
       mute_logger do
         if @zk.connected?
-          @zk.close! 
+          @zk.close!
           wait_until { !@zk.connected? }
         end
 
@@ -48,8 +48,8 @@ describe ZK do
         pending_in_travis("these tests take too long or time out")
       end
 
-      # this is stupid, and a bad test, but we have to check that events 
-      # don't get re-delivered to a single registered callback just because 
+      # this is stupid, and a bad test, but we have to check that events
+      # don't get re-delivered to a single registered callback just because
       # :watch => true was called twice
       #
       # again, we're testing a negative here, so consider this a regression check

--- a/spec/zk/watch_spec.rb
+++ b/spec/zk/watch_spec.rb
@@ -44,9 +44,9 @@ describe ZK do
     end
 
     describe :regression do
-      before do
-        pending_in_travis("these tests take too long or time out")
-      end
+      # before do
+      #   pending_in_travis("these tests take too long or time out")
+      # end
 
       # this is stupid, and a bad test, but we have to check that events
       # don't get re-delivered to a single registered callback just because

--- a/spec/zk/zookeeper_spec.rb
+++ b/spec/zk/zookeeper_spec.rb
@@ -11,58 +11,58 @@ shared_examples_for 'ZK basic' do
 
   describe ZK, "with no authentication" do
     it "should add authentication" do
-      @zk.add_auth({:scheme => 'digest', :cert => 'bob:password'}).should include({:rc => 0})
+      expect(@zk.add_auth({:scheme => 'digest', :cert => 'bob:password'})).to include({:rc => 0})
     end
   end
 
   describe ZK, "with no paths" do
     it "should not exist" do
-      @zk.exists?("#{@base_path}/test").should be_false
+      expect(@zk.exists?("#{@base_path}/test")).to be(false)
     end
 
     it "should create a path" do
-      @zk.create("#{@base_path}/test", "test_data", :mode => :ephemeral).should == "#{@base_path}/test"
+      expect(@zk.create("#{@base_path}/test", "test_data", :mode => :ephemeral)).to eq("#{@base_path}/test")
     end
 
     it "should be able to set the data" do
       @zk.create("#{@base_path}/test", "something", :mode => :ephemeral)
       @zk.set("#{@base_path}/test", "somethingelse")
-      @zk.get("#{@base_path}/test").first.should == "somethingelse"
+      expect(@zk.get("#{@base_path}/test").first).to eq("somethingelse")
     end
 
     it "should raise an exception for a non existent path" do
-      lambda { @zk.get("/non_existent_path") }.should raise_error(ZK::Exceptions::NoNode)
+      expect { @zk.get("/non_existent_path") }.to raise_error(ZK::Exceptions::NoNode)
     end
 
     it "should create a path with sequence set" do
-      @zk.create("#{@base_path}/test", "test_data", :mode => :persistent_sequential).should =~ /test(\d+)/
+      expect(@zk.create("#{@base_path}/test", "test_data", :mode => :persistent_sequential)).to match(/test(\d+)/)
     end
 
     it "should create an ephemeral path" do
-      @zk.create("#{@base_path}/test", "test_data", :mode => :ephemeral).should == "#{@base_path}/test"
+      expect(@zk.create("#{@base_path}/test", "test_data", :mode => :ephemeral)).to eq("#{@base_path}/test")
     end
 
     it "should remove ephemeral path when client session ends" do
-      @zk.create("#{@base_path}/test", "test_data", :mode => :ephemeral).should == "#{@base_path}/test"
-      @zk.exists?("#{@base_path}/test").should_not be_nil
+      expect(@zk.create("#{@base_path}/test", "test_data", :mode => :ephemeral)).to eq("#{@base_path}/test")
+      expect(@zk.exists?("#{@base_path}/test")).not_to be_nil
       @zk.close!
       wait_until(2) { !@zk.connected? }
-      @zk.should_not be_connected
+      expect(@zk).not_to be_connected
 
       @zk = ZK.new(*connection_args)
       wait_until{ @zk.connected? }
-      @zk.exists?("#{@base_path}/test").should be_false
+      expect(@zk.exists?("#{@base_path}/test")).to be(false)
     end
 
     it "should remove sequential ephemeral path when client session ends" do
       created = @zk.create("#{@base_path}/test", "test_data", :mode => :ephemeral_sequential)
-      created.should =~ /test(\d+)/
-      @zk.exists?(created).should_not be_nil
+      expect(created).to match(/test(\d+)/)
+      expect(@zk.exists?(created)).not_to be_nil
       @zk.close!
 
       @zk = ZK.new(*connection_args)
       wait_until{ @zk.connected? }
-      @zk.exists?(created).should be_false
+      expect(@zk.exists?(created)).to be(false)
     end
   end
 
@@ -72,57 +72,57 @@ shared_examples_for 'ZK basic' do
     end
 
     it "should return a stat" do
-      @zk.stat("#{@base_path}/test").should be_instance_of(Zookeeper::Stat)
+      expect(@zk.stat("#{@base_path}/test")).to be_instance_of(Zookeeper::Stat)
     end
 
     it "should return a boolean" do
-      @zk.exists?("#{@base_path}/test").should be_true
+      expect(@zk.exists?("#{@base_path}/test")).to be(true)
     end
 
     it "should get data and stat" do
       data, stat = @zk.get("#{@base_path}/test")
-      data.should == "test_data"
-      stat.should be_a_kind_of(Zookeeper::Stat)
-      stat.created_time.should_not == 0
+      expect(data).to eq("test_data")
+      expect(stat).to be_a_kind_of(Zookeeper::Stat)
+      expect(stat.created_time).not_to eq(0)
     end
 
     it "should set data with a file" do
       file = File.read('spec/test_file.txt')
       @zk.set("#{@base_path}/test", file)
-      @zk.get("#{@base_path}/test").first.should == file
+      expect(@zk.get("#{@base_path}/test").first).to eq(file)
     end
 
     it "should delete path" do
       @zk.delete("#{@base_path}/test")
-      @zk.exists?("#{@base_path}/test").should be_false
+      expect(@zk.exists?("#{@base_path}/test")).to be(false)
     end
 
     it "should create a child path" do
-      @zk.create("#{@base_path}/test/child", "child", :mode => :ephemeral).should == "#{@base_path}/test/child"
+      expect(@zk.create("#{@base_path}/test/child", "child", :mode => :ephemeral)).to eq("#{@base_path}/test/child")
     end
 
     it "should create sequential child paths" do
-      (child1 = @zk.create("#{@base_path}/test/child", "child1", :mode => :persistent_sequential)).should =~ /\/test\/child(\d+)/
-      (child2 = @zk.create("#{@base_path}/test/child", "child2", :mode => :persistent_sequential)).should =~ /\/test\/child(\d+)/
+      expect(child1 = @zk.create("#{@base_path}/test/child", "child1", :mode => :persistent_sequential)).to match(/\/test\/child(\d+)/)
+      expect(child2 = @zk.create("#{@base_path}/test/child", "child2", :mode => :persistent_sequential)).to match(/\/test\/child(\d+)/)
       children = @zk.children("#{@base_path}/test")
-      children.length.should == 2
-      children.should be_include(child1.match(/\/test\/(child\d+)/)[1])
-      children.should be_include(child2.match(/\/test\/(child\d+)/)[1])
+      expect(children.length).to eq(2)
+      expect(children).to be_include(child1.match(/\/test\/(child\d+)/)[1])
+      expect(children).to be_include(child2.match(/\/test\/(child\d+)/)[1])
     end
 
     it "should have no children" do
-      @zk.children("#{@base_path}/test").should be_empty
+      expect(@zk.children("#{@base_path}/test")).to be_empty
     end
   end
 
   describe ZK, "with children" do
     before(:each) do
       @zk.create("#{@base_path}/test", "test_data", :mode => :persistent)
-      @zk.create("#{@base_path}/test/child", "child", :mode => "persistent").should == "#{@base_path}/test/child"
+      expect(@zk.create("#{@base_path}/test/child", "child", :mode => "persistent")).to eq("#{@base_path}/test/child")
     end
 
     it "should get children" do
-      @zk.children("#{@base_path}/test").should eql(["child"])
+      expect(@zk.children("#{@base_path}/test")).to eql(["child"])
     end
   end
 end

--- a/spec/zk/zookeeper_spec.rb
+++ b/spec/zk/zookeeper_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 shared_examples_for 'ZK basic' do
   before do
-    logger.debug { "connection_args: #{connection_args.inspect}" } 
+    logger.debug { "connection_args: #{connection_args.inspect}" }
     begin
       @zk.create(@base_path)
     rescue ZK::Exceptions::NodeExists


### PR DESCRIPTION
Not sure whether this is the PR you expected, but ...

@nerdrew did quite a bit of work for RSpec3 integration, which I cherry-picked

Also:

- added Ruby 2.3.0, 2.4.0
- removed Ruby ree, 1.8.7 Travis testing
- re-enabled some Travis tests
- moved a gem from 'development' to 'test' section

and tadaa, it builds ok for all reasonably current Ruby versions per https://travis-ci.org/berlincount/zk